### PR TITLE
feat(gh-pages): add an index.html to redirect the Helm charts repository URL to the Github repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <link rel="canonical" href="https://github.com/jenkins-infra/helm-charts/" />
+        <noscript>
+            <meta http-equiv="refresh" content="0; URL=https://github.com/jenkins-infra/helm-charts/" />
+        </noscript>
+    </head>
+    <body>
+        <script type="text/javascript">
+            window.location.replace("https://github.com/jenkins-infra/helm-charts")
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The [current gh-pages index](https://jenkins-infra.github.io/helm-charts) doesn't provide such useful information:

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/91831478/146549918-fb21df6c-901a-4d23-89cf-94c920f7b03f.png">


With this PR, consulting https://jenkins-infra.github.io/helm-charts with a browser (for the devs) will redirect to this Github repository homepage, which can be handy when wanting to know more about a chart than just the command to add the helm repo.

It doesn't touch the index.yaml, nothing change on the helm side.

