### PR TITLE
feat(gh-pages): add an index.html to redirect the Helm charts repository URL to the Github repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <link rel="canonical" href="https://github.com/jenkins-infra/helm-charts/" />
+        <noscript>
+            <meta http-equiv="refresh" content="0; URL=https://github.com/jenkins-infra/helm-charts/" />
+        </noscript>
+    </head>
+    <body>
+        <script type="text/javascript">
+            window.location.replace("https://github.com/jenkins-infra/helm-charts")
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
mistake..