### PR TITLE
chore(updatecli) track geoip image version for mirrorbits

### DIFF
--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -1,4 +1,17 @@
 title: Bump `mirrorbits` docker images version and helm chart version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   latestMirrorbitsRelease:
     name: Get latest version of jenkinsciinfra/mirrorbits
@@ -10,13 +23,12 @@ sources:
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
   latestHttpdRelease:
-    name: Get latest version of httpd
-    kind: githubRelease
+    name: Get latest digest of the Docker Image for httpd, in version 2.4
+    kind: dockerDigest
     spec:
-      owner: "docker-library"
-      repository: "httpd"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
+      image: "httpd"
+      tag: "2.4"
+      architecture: "amd64"
   chartVersion:
     name: Get mirrorbits helm chart version
     kind: yaml
@@ -25,6 +37,7 @@ sources:
       key: "version"
     transformers:
       - semverInc: "patch"
+
 conditions:
   checkMirrorbitsDockerImagePublished:
     name: Ensure that the image "jenkinsciinfra/mirrorbits:<found_version>" is published on the DockerHub
@@ -32,13 +45,10 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/mirrorbits"
-  checkHttpdDockerImagePublished:
-    name: Ensure that the image "httpd:<found_version>" is published on the DockerHub
-    sourceID: latestMirrorbitsRelease
-    kind: dockerImage
-    spec:
-      image: "_/httpd"
+      architecture: "amd64"
+      # Tags comes from sourceID
   # no condition to test httpd docker image availability as we're using a digest from docker hub
+
 targets:
   updateMirrorbits:
     name: "Update mirrorbits docker image version"
@@ -47,15 +57,7 @@ targets:
     spec:
       file: charts/mirrorbits/values.yaml
       key: "image.mirrorbits.tag"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository}}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateHttpd:
     name: "Update httpd docker image version"
     sourceID: latestHttpdRelease
@@ -63,15 +65,7 @@ targets:
     spec:
       file: charts/mirrorbits/values.yaml
       key: "image.files.tag"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository}}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
   updateChartVersion:
     name: Bump mirrorbits helm chart version
     kind: yaml
@@ -79,12 +73,17 @@ targets:
     spec:
       file: "charts/mirrorbits/Chart.yaml"
       key: "version"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateMirrorbits
+      - updateHttpd
+      - updateChartVersion
+    spec:
+      labels:
+        - dependencies
+        - mirrorbits

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -29,6 +29,14 @@ sources:
       image: "httpd"
       tag: "2.4"
       architecture: "amd64"
+  latestGeoIPRelease:
+    name: Get latest version of GeoIP
+    kind: githubRelease
+    spec:
+      owner: "maxmind"
+      repository: "geoipupdate"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
   chartVersion:
     name: Get mirrorbits helm chart version
     kind: yaml
@@ -46,7 +54,15 @@ conditions:
     spec:
       image: "jenkinsciinfra/mirrorbits"
       architecture: "amd64"
-      # Tags comes from sourceID
+      # Tag comes from sourceID
+  checkGeoIPDockerImagePublished:
+    name: Ensure that the image "maxmindinc/geoipupdate:<found_version>" is published on the DockerHub
+    sourceID: latestGeoIPRelease
+    kind: dockerImage
+    spec:
+      image: "maxmindinc/geoipupdate"
+      architecture: "amd64"
+      # Tag comes from sourceID
   # no condition to test httpd docker image availability as we're using a digest from docker hub
 
 targets:
@@ -65,6 +81,14 @@ targets:
     spec:
       file: charts/mirrorbits/values.yaml
       key: "image.files.tag"
+    scmID: default
+  updateGeoIP:
+    name: "Update maxmindinc/geoipupdate docker image version"
+    sourceID: latestGeoIPRelease
+    kind: yaml
+    spec:
+      file: charts/mirrorbits/values.yaml
+      key: "geoipupdate.image.tag"
     scmID: default
   updateChartVersion:
     name: Bump mirrorbits helm chart version


### PR DESCRIPTION
This PR ensures that updatecli tracks geoip image version for mirrorbits.

It also fixes the manifest to be compliant with updatecli 0.18.0.