### PR TITLE
fix: use correct separator between blacklist labels

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.0.1
+version: 0.0.2
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -147,7 +147,7 @@ multibranchPipelineJob('{{ .fullId }}') {
             pruneStaleBranchTrait()
             gitHubTagDiscovery()
             pullRequestLabelsBlackListFilterTrait {
-              labels('on-hold ci-skip skip-ci')
+              labels('on-hold,ci-skip,skip-ci')
             }
             // Select branches and tags to build based on these filters
             headWildcardFilterWithPR {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/91831478/160837694-32e6e1e0-13e7-4120-89f7-160b18bcc0be.png)

After:
![image](https://user-images.githubusercontent.com/91831478/160837733-4805b062-8694-4aef-aae9-dfe54eb4d831.png)
