### PR TITLE
feat(rating): new release with boolean flag for readynessProbe and single quotes attributes

### DIFF
--- a/charts/rating/templates/deployment.yaml
+++ b/charts/rating/templates/deployment.yaml
@@ -35,10 +35,12 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.readinessProbe.enabled -}}
           readinessProbe:
             httpGet:
               path: /rate/result.php
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/rating/templates/secret.yaml
+++ b/charts/rating/templates/secret.yaml
@@ -7,8 +7,8 @@ metadata:
 stringData:
   dbconfig.php: |
     <?php
-    $dbuser={{ .Values.database.username | quote }};
-    $dbpass={{ .Values.database.password | quote }};
-    $dbname={{ .Values.database.name | quote }};
-    $dbserver={{ .Values.database.server | quote }};
-    $dbport={{ .Values.database.port | toString | quote }};
+    $dbuser={{ .Values.database.username | squote }};
+    $dbpass={{ .Values.database.password | squote }};
+    $dbname={{ .Values.database.name | squote }};
+    $dbserver={{ .Values.database.server | squote }};
+    $dbport={{ .Values.database.port | toString | squote }};

--- a/charts/rating/values.yaml
+++ b/charts/rating/values.yaml
@@ -70,6 +70,10 @@ tolerations: []
 
 affinity: {}
 
+#flag to disable readinessProbe in deployment.yaml L38
+readinessProbe:
+  enabled: false
+
 database:
   username: rating
   password: s3cr3t


### PR DESCRIPTION
add a boolean flag to disable readynessProbe from the helmchart
and switch double quotes to single ones for php strings : https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.single