### PR TITLE
chore(jenkinsfile) delegate credential to updatecli library + ensure it runs daily

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,6 +1,4 @@
-withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-        updatecli(action: 'apply')
-    }
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
 }


### PR DESCRIPTION
The Jenkins builds of this repository are failing with the error message `ERROR: Could not find credentials entry with ID 'updatecli-github-token'`.

It happens since https://github.com/jenkins-infra/kubernetes-management/pull/2138 because the credential `updatecli-github-token` was removed.

It is expected that we use the GitHub app credential instead (thanks @to @lemeurherve 's awesome work).

This PR intent is to fix this behavior by using the default credential of the `updatecli()` pipeline library (which is the github app credential).