### PR TITLE
fix(jenkins-jobs) correct SSH credentials + folder jobs syntax

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.0.3
+version: 0.0.4
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -342,7 +342,8 @@ configNode << 'com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPri
   {{- end }}
   usernameSecret({{ .usernameSecret | default false}})
   privateKeySource(class:"com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey\$DirectEntryPrivateKeySource") {
-    privateKey('{{ .privateKey }}')
+    privateKey('''{{ .privateKey }}''')
+
   }
 }
 {{- end }}

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -96,7 +96,7 @@ properties {
 {{/*
 Generate the job-dsl definition of a folder
 */}}
-{{- define "folder-job-dsl-definition" -}}
+{{- define "folder-job-dsl-definition" }}
 folder('{{ .id }}') {
 {{ include "common-job-dsl-definition" . | indent 2 }}
 }


### PR DESCRIPTION
This PR closes #104, and also fix a bug introduced in #111 around folder jobs.