### PR TITLE
feat(jenkins-jobs) add support of githubapp credentials

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.0.4
+version: 0.1.0
 appVersion: "1.0" # unused


### PR DESCRIPTION
This PR fixes #109 by adding support for githubapp credentials.

Please not that it supports 3 different possible cases for the attribute `appid`, given the risk of mistyping by end users 😅