### PR TITLE
feat(jenkins-jobs) allow to disable github checks at all

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -131,7 +131,7 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
             gitHubSCMSourceStatusChecksTrait {
               // Note: changing this name might have impact on github branch protections if they specify status names
               name('[infra.ci.jenkins.io] {{ .name }}')
-              skip(false)
+              skip({{ .disableGitHubChecks | default "false" }})
               // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
               skipNotifications(false)
               skipProgressUpdates(false)


### PR DESCRIPTION
This PR allows jobs to ensure that no information other than the build status are sent to github checks (needed for infra-reports - https://github.com/jenkins-infra/helpdesk/issues/2789)