### PR TITLE
chore(updatecli) fix manifest issues for 0.23.x + track plugin-site-issues docker image

### DIFF
--- a/updatecli/updatecli.d/custom-distribution-service.yaml
+++ b/updatecli/updatecli.d/custom-distribution-service.yaml
@@ -28,11 +28,11 @@ conditions:
   checkDockerImagePublished:
     name: Is latest jenkinsciinfra/custom-distribution-service docker image published
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/custom-distribution-service"
       architecture: "amd64"
-      # Tag comes from sourceID
+      # Tag comes from sourceid
 
 targets:
   updateChart:
@@ -42,12 +42,12 @@ targets:
       name: charts/custom-distribution-service
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:

--- a/updatecli/updatecli.d/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/incrementals-publisher.yaml
@@ -26,7 +26,7 @@ conditions:
   checkDockerImagePublished:
     name: Test if jenkinsciinfra/incrementals-publisher docker image is published
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/incrementals-publisher"
       architecture: "amd64"
@@ -39,12 +39,12 @@ targets:
       name: charts/incrementals-publisher
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:

--- a/updatecli/updatecli.d/jenkins-wiki-exporter.yaml
+++ b/updatecli/updatecli.d/jenkins-wiki-exporter.yaml
@@ -29,7 +29,7 @@ conditions:
   checkDockerImagePublished:
     name: Test jenkinsciinfra/jenkins-wiki-exporter:<latest_version> docker image tag
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/jenkins-wiki-exporter"
       architecture: "amd64"
@@ -42,12 +42,12 @@ targets:
       name: charts/jenkins-wiki-exporter
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:

--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -19,12 +19,14 @@ sources:
     spec:
       image: "jenkinsciinfra/ldap"
       tag: "cron-latest"
+      architecture: "amd64"
   slapd:
     kind: dockerDigest
     name: Get jenkinsciinfra/ldap:latest docker image digest
     spec:
       image: "jenkinsciinfra/ldap"
       tag: "latest"
+      architecture: "amd64"
 
 # no condition to test docker image availability as we're using a digest from docker hub
 
@@ -32,26 +34,26 @@ targets:
   updateChartCrond:
     name: Update jenkins-wiki-exporter helm chart
     kind: helmChart
-    sourceID: crond
+    sourceid: crond
     spec:
       name: charts/ldap
       key: image.crond.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
   updateChartSlapd:
     name: Update jenkins-wiki-exporter helm chart
     kind: helmChart
-    sourceID: slapd
+    sourceid: slapd
     spec:
       name: charts/ldap
       key: image.slapd.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartCrond
       - updateChartSlapd

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -41,54 +41,54 @@ sources:
 conditions:
   checkMirrorbitsDockerImagePublished:
     name: Ensure that the image "jenkinsciinfra/mirrorbits:<found_version>" is published on the DockerHub
-    sourceID: latestMirrorbitsRelease
+    sourceid: latestMirrorbitsRelease
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/mirrorbits"
       architecture: "amd64"
-      # Tag comes from sourceID
+      # Tag comes from sourceid
   checkGeoIPDockerImagePublished:
     name: Ensure that the image "maxmindinc/geoipupdate:<found_version>" is published on the DockerHub
-    sourceID: latestGeoIPRelease
+    sourceid: latestGeoIPRelease
     kind: dockerImage
     spec:
       image: "maxmindinc/geoipupdate"
       architecture: "amd64"
-      # Tag comes from sourceID
+      # Tag comes from sourceid
 
 # no condition to test httpd docker image availability as we're using a digest from docker hub
 
 targets:
   updateMirrorbits:
     name: "Update mirrorbits docker image version"
-    sourceID: latestMirrorbitsRelease
+    sourceid: latestMirrorbitsRelease
     kind: helmChart
     spec:
       name: charts/mirrorbits
       key: "image.mirrorbits.tag"
       versionincrement: patch
-    scmID: default
+    scmid: default
   updateHttpd:
     name: "Update httpd docker image version"
-    sourceID: latestHttpdRelease
+    sourceid: latestHttpdRelease
     kind: helmChart
     spec:
       name: charts/mirrorbits
       key: "image.files.tag"
-    scmID: default
+    scmid: default
   updateGeoIP:
     name: "Update maxmindinc/geoipupdate docker image version"
-    sourceID: latestGeoIPRelease
+    sourceid: latestGeoIPRelease
     kind: helmChart
     spec:
       name: charts/mirrorbits
       key: "geoipupdate.image.tag"
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateMirrorbits
       - updateHttpd

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -21,7 +21,7 @@ sources:
   latestRelease:
     name: Get latest stable version of nginx
     kind: gitTag
-    scmID: nginxGithubMirror
+    scmid: nginxGithubMirror
     spec:
       versionFilter:
         kind: regex
@@ -35,7 +35,7 @@ conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "nginx"
       architecture: amd64
@@ -49,7 +49,7 @@ targets:
       name: charts/javadoc
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
   updateJenkinsioChartEn:
     name: "Update nginx stable docker image version for jenkinsio chart (EN)"
     kind: helmChart
@@ -57,7 +57,7 @@ targets:
       name: charts/jenkinsio
       key: images.en.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
   updateJenkinsioChartZh:
     name: "Update nginx stable docker image version for jenkinsio chart (ZH)"
     kind: helmChart
@@ -65,7 +65,7 @@ targets:
       name: charts/jenkinsio
       key: images.zh.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
   updatePluginSiteChart:
     name: "Update nginx stable docker image version for plugin-site chart"
     kind: helmChart
@@ -73,7 +73,7 @@ targets:
       name: charts/plugin-site
       key: frontend.image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
   updateReportsChart:
     name: "Update nginx stable docker image version for reports chart"
     kind: helmChart
@@ -81,12 +81,12 @@ targets:
       name: charts/reports
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateJavadocChart
       - updateJenkinsioChartEn

--- a/updatecli/updatecli.d/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/plugin-site-issues.yaml
@@ -1,0 +1,54 @@
+title: Bump `plugin-site-issues` docker image and helm chart versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestRelease:
+    kind: githubRelease
+    name: "Get latest jenkins-infra/docker-plugin-site-issues latest version"
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-plugin-site-issues"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkDockerImagePublished:
+    name: |
+      Test jenkinsciinfra/docker-plugin-site-issues:{{ source `latestRelease` }} docker image tag
+    kind: dockerImage
+    sourceid: latestRelease
+    spec:
+      image: "jenkinsciinfra/plugin-site-issues"
+      architecture: "amd64"
+
+targets:
+  updateChart:
+    name: Update rating helm chart
+    kind: helmChart
+    spec:
+      name: charts/plugin-site-issues
+      key: image.tag
+      versionincrement: patch
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - updateChart
+    spec:
+      labels:
+        - dependencies
+        - plugin-site-issues

--- a/updatecli/updatecli.d/rating.yaml
+++ b/updatecli/updatecli.d/rating.yaml
@@ -28,7 +28,7 @@ conditions:
     name: |
       Test jenkinsciinfra/rating:{{ source `latestRelease` }} docker image tag
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/rating"
       architecture: "amd64"
@@ -41,12 +41,12 @@ targets:
       name: charts/rating
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -19,6 +19,7 @@ sources:
     spec:
       image: "jenkinsciinfra/uplink"
       tag: "latest"
+      architecture: "amd64"
 
 # no condition to test docker image availability as we're using a digest from docker hub
 
@@ -30,12 +31,12 @@ targets:
       name: charts/uplink
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:

--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -27,7 +27,7 @@ conditions:
   checkDockerImagePublished:
     name: "Test jenkinsciinfra/wiki:<latest_version> docker image tag"
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/wiki"
       architecture: "amd64"
@@ -40,12 +40,12 @@ targets:
       name: charts/wiki
       key: image.tag
       versionincrement: patch
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChart
     spec:


### PR DESCRIPTION
This PR updates updatecli manifests + ensure that the Docker image tag for plugin-site-issue is automatically tracked (with check).