### PR TITLE
feat(jenkins-jobs) change github checks defaults + allow customization

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -130,12 +130,13 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
           traits {
             gitHubSCMSourceStatusChecksTrait {
               // Note: changing this name might have impact on github branch protections if they specify status names
-              name('[infra.ci.jenkins.io] {{ .name }}')
+              name({{ .githubCheckName | default "jenkins" | squote }})
               skip({{ .disableGitHubChecks | default "false" }})
               // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
               skipNotifications(false)
               skipProgressUpdates(false)
               // Default value: false. Warning: risk of secret leak in console if the build fails
+              // Please note that it only disable the detailled logs. If you really want no logs, then use "skip(false)' instead
               suppressLogs(true)
               unstableBuildNeutral(false)
             }

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -131,7 +131,11 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
             gitHubSCMSourceStatusChecksTrait {
               // Note: changing this name might have impact on github branch protections if they specify status names
               name({{ .githubCheckName | default "jenkins" | squote }})
-              skip({{ .disableGitHubChecks | default "false" }})
+              {{- if empty .enableGitHubChecks }}
+              skip(true)
+              {{- else }}
+              skip({{ not .enableGitHubChecks }})
+              {{- end }}
               // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
               skipNotifications(false)
               skipProgressUpdates(false)

--- a/charts/jenkins-jobs/values.yaml
+++ b/charts/jenkins-jobs/values.yaml
@@ -29,6 +29,8 @@ jobsDefinition: {}
 #       multibranchJobB: ## ## Default to kind: multibranchJob with id == name == description and default settings
 #       multibranchJobC: ## Default to kind: multibranchJob
 #         name: Job C
+#         enableGitHubChecks: true
+#         githubCheckName: RogerRoger
 #         credentials:
 #            ssh-deploy-key:
 #              username: ${SSH_CHARTS_SECRETS_USERNAME}


### PR DESCRIPTION
This PR follows up https://github.com/jenkins-infra/helpdesk/issues/2884 and introduce the following changes:

- GitHub Checks are disabled by default (only pipeline status is reported)
  - You can enable them by specifying the new attribute `enableGitHubChecks: true`
  - The former attribute `disableGitHubChecks` is deprecated (and ignored)

- GitHub Checks default name is back to `jenkins`
  - You can customize it by specifying the new name with the new `githubCheckName` attribute