### PR TITLE
feat(httpredirector) enable tls by default with certmanager annotation

### DIFF
--- a/charts/httpredirector/Chart.yaml
+++ b/charts/httpredirector/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0

--- a/charts/httpredirector/templates/ingress.yaml
+++ b/charts/httpredirector/templates/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+{{- if .Values.tls }}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+{{- end }}
     nginx.ingress.kubernetes.io/permanent-redirect: {{ .Values.urlredirect }}
     nginx.ingress.kubernetes.io/permanent-redirect-code: "308"
   name: "{{ .Release.Name }}-{{ .Values.host }}"
@@ -9,3 +12,9 @@ spec:
   ingressClassName: {{ .Values.ingressClassName }}
   rules:
   - host: {{ .Values.host }}
+{{- if .Values.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.host }}
+    secretName: {{ .Release.Name }}-tls
+{{- end }}

--- a/charts/httpredirector/tests/defaults_test.yaml
+++ b/charts/httpredirector/tests/defaults_test.yaml
@@ -16,8 +16,21 @@ tests:
           path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect]
           value: "http://demo.localhost.me"
       - equal:
+          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect-code]
+          value: "308"
+      - equal:
+          path: metadata.annotations.[cert-manager.io/cluster-issuer]
+          value: "letsencrypt-prod"
+      - equal:
           path: spec.rules[0].host
           value: "localhost"
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: "localhost"
+      # The release name defaults to "RELEASE-NAME" within helm-unittest
+      - equal:
+          path: spec.tls[0].secretName
+          value: "RELEASE-NAME-tls"
       - equal:
           path: spec.ingressClassName
           value: "nginx"

--- a/charts/httpredirector/tests/withvalues_test.yaml
+++ b/charts/httpredirector/tests/withvalues_test.yaml
@@ -7,6 +7,7 @@ tests:
       urlredirect: "http://my.domain.com"
       host: domain
       ingressClassName: "public-nginx"
+      tls: false
     asserts:
       - hasDocuments:
           count: 1
@@ -20,8 +21,13 @@ tests:
           path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect]
           value: "http://my.domain.com"
       - equal:
+          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect-code]
+          value: "308"
+      - equal:
           path: spec.rules[0].host
           value: "domain"
       - equal:
           path: spec.ingressClassName
           value: "public-nginx"
+      - isNull:
+          path: spec.tls

--- a/charts/httpredirector/values.yaml
+++ b/charts/httpredirector/values.yaml
@@ -1,3 +1,4 @@
 urlredirect: http://demo.localhost.me
 host: localhost
 ingressClassName: nginx
+tls: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2943

This PR enables TLS (with the certmanager annotation for our environment) by default.