### PR TITLE
hotfix(env-jenkins-release) specify the secret namespace

### DIFF
--- a/charts/env-jenkins-release/Chart.yaml
+++ b/charts/env-jenkins-release/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Jenkins Release Environment Chart
 name: env-jenkins-release
-version: 0.1.1
+version: 0.1.2

--- a/charts/env-jenkins-release/templates/core-packages.yaml
+++ b/charts/env-jenkins-release/templates/core-packages.yaml
@@ -23,6 +23,7 @@ spec:
     - ReadWriteMany
   azureFile:
     secretName: core-packages
+    secretNamespace: {{ .Release.Namespace }}
     shareName: {{ .Values.corePackages.shareName }}
     readOnly: false
   mountOptions:
@@ -63,6 +64,7 @@ spec:
     - ReadWriteMany
   azureFile:
     secretName: core-packages
+    secretNamespace: {{ .Release.Namespace }}
     shareName: {{ .Values.corePackages.websiteShareName }}
     readOnly: false
   mountOptions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3037 and https://github.com/Azure/AKS/issues/2871

as per the AKS CSI for Kube 1.22+ (ref. https://github.com/jenkins-infra/helpdesk/issues/2930), we have to specify the namespace where the SAS token lives, otherwises Kubernetes searches on the `default` namespace.

- Same hotfix as https://github.com/jenkins-infra/helm-charts/pull/158 but for the release.ci.jenkins.io environment
- Long term fix: as https://github.com/jenkins-infra/helpdesk/issues/2930 will underline, we need to check all of the PVs to use the latest CSI driver, or at least patch all the remaining `azurefile` PVs.