### PR TITLE
fix(javadoc/jenkins.io/reports): specify secretNamespace in README examples

### DIFF
--- a/charts/javadoc/README.md
+++ b/charts/javadoc/README.md
@@ -53,9 +53,10 @@ Here's some example configuration for running this on Azure:
 azureStorageAccountName: myaccount
 azureStorageAccountKey: key
 htmlVolume:
-  azureFile: 
-    secretName: reports
-    shareName: reports
+  azureFile:
+    secretName: javadoc
+    secretNamespace: javadoc
+    shareName: javadoc
     readOnly: true
 # ... you will also need ingress configuration, add as required
 ```

--- a/charts/jenkinsio/README.md
+++ b/charts/jenkinsio/README.md
@@ -70,12 +70,14 @@ azureStorageAccountKey: key
 htmlVolume:
   azureFile: 
     secretName: jenkinsio
+    secretNamespace: jenkinsio
     shareName: jenkinsio
     readOnly: true
 
 zhHtmlVolume:
   azureFile: 
     secretName: jenkinsio
+    secretNamespace: jenkinsio
     shareName: zhjenkinsio
     readOnly: true
 # ... you will also need ingress configuration, add as required

--- a/charts/reports/README.md
+++ b/charts/reports/README.md
@@ -56,6 +56,7 @@ azureStorageAccountKey: key
 htmlVolume:
   azureFile: 
     secretName: reports
+    secretNamespace: reports
     shareName: reports
     readOnly: true
 


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3037