### PR TITLE
chore: align database parameter names with existing ones

### DIFF
--- a/charts/plugin-health-scoring/Chart.yaml
+++ b/charts/plugin-health-scoring/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: plugin-health-scoring
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
-appVersion: 0.0.1
+version: 1.1.0

--- a/charts/plugin-health-scoring/templates/deployment.yaml
+++ b/charts/plugin-health-scoring/templates/deployment.yaml
@@ -51,11 +51,11 @@ spec:
             - name: PROBE_ENGINE_CRON
               value: {{ .Values.config.peCron | squote }}
             - name: POSTGRES_HOST
-              value: {{ .Values.database.host | squote }}
+              value: {{ .Values.database.server | squote }}
             - name: POSTGRES_PORT
               value: {{ .Values.database.port | squote }}
             - name: POSTGRES_DB
-              value: {{ .Values.database.db | squote }}
+              value: {{ .Values.database.name | squote }}
             - name: POSTGRES_USER
               value: {{ .Values.database.user | squote }}
             - name: POSTGRES_PASSWORD

--- a/charts/plugin-health-scoring/templates/secret.yaml
+++ b/charts/plugin-health-scoring/templates/secret.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "plugin-health-scoring.fullname" . }}
-  labels:
-{{ include "plugin-health-scoring.labels" . | indent 4 }}

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -66,6 +66,6 @@ config:
 database:
   user: plugin-health-scoring
   password: s3cr3t
-  db: plugin-health-scoring
-  host: postgresql
+  name: plugin-health-scoring
+  server: postgresql
   port: 5432


### PR DESCRIPTION
Allowing us to terraform output similar secrets:
- https://github.com/jenkins-infra/azure/blob/b7fe7ac9e238ee1172f0bdac7188f720ba99dd8c/rating.jenkins.io.tf#L23-L27
- https://github.com/jenkins-infra/azure/blob/b7fe7ac9e238ee1172f0bdac7188f720ba99dd8c/plugin-health.jenkins.io.tf#L23-L27

Also, removed secret.yaml (unused), and Charts.yaml/appVersion (we're using and updating values.yaml/image.tag)