### PR TITLE
Updatecli: Add/Update manifests to track more elements

### DIFF
--- a/charts/accountapp/Chart.yaml
+++ b/charts/accountapp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for accounts.jenkins.io
-name: accountapp
 maintainers:
-  - name: timja
-version: 0.1.0
+- name: timja
+name: accountapp
+version: 0.1.1

--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -3,18 +3,15 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
-
 image:
   repository: jenkinsciinfra/account-app
-
+  tag: 0.0.7
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
 service:
   type: ClusterIP
   port: 8080
-
 # Please define ingress settings into environment variable
 ingress:
   enabled: true
@@ -34,45 +31,36 @@ ingress:
 #        - accounts.jenkins.io
 
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
-
 ldap:
   url: ldaps://ldap.jenkins.io:636/
   managerDn: cn=admin,dc=jenkins-ci,dc=org
   newUserBaseDn: ou=people,dc=jenkins-ci,dc=org
   password:
-
 jira:
   username: accountapp
   password:
   url: https://issues.jenkins.io/
-
 seats: 2
 seniority: 12
-
 smtp:
   auth: true
   server: smtp.sendgrid.net
   user:
   password:
-
 appUrl: https://accounts.jenkins.io
-
 election:
   open: 1970-01-01
   close: 1970-01-02

--- a/updatecli/updatecli.d/accountapp.yaml
+++ b/updatecli/updatecli.d/accountapp.yaml
@@ -1,4 +1,4 @@
-title: Bump account-app docker image version
+name: Bump account-app docker image version
 
 scms:
   default:

--- a/updatecli/updatecli.d/accountapp.yaml
+++ b/updatecli/updatecli.d/accountapp.yaml
@@ -45,7 +45,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump accountapp docker version to {{ source "latestRelease" }}
+    title: Bump `accountapp` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/accountapp.yaml
+++ b/updatecli/updatecli.d/accountapp.yaml
@@ -1,0 +1,52 @@
+title: Bump account-app docker image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestRelease:
+    kind: githubrelease
+    name: "Get latest jenkins-infra/account-app release"
+    spec:
+      owner: "jenkins-infra"
+      repository: "account-app"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkDockerImagePublished:
+    name: "Test jenkinsciinfra/account-app:<latest_version> docker image tag"
+    kind: dockerimage
+    spec:
+      image: "jenkinsciinfra/account-app"
+      ## Tag from source
+      architecture: amd64
+
+targets:
+  updateChart:
+    name: Update accountapp helm chart
+    kind: helmchart
+    spec:
+      name: charts/accountapp
+      key: image.tag
+      versionincrement: patch
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump accountapp docker version to {{ source "latestRelease" }}
+    spec:
+      labels:
+        - dependencies
+        - accountapp

--- a/updatecli/updatecli.d/custom-distribution-service.yaml
+++ b/updatecli/updatecli.d/custom-distribution-service.yaml
@@ -1,4 +1,4 @@
-title: Bump `custom-distribution-service` docker image and helm chart versions
+name: Bump `custom-distribution-service` docker image and helm chart versions
 
 scms:
   default:
@@ -15,19 +15,19 @@ scms:
 sources:
   latestRelease:
     name: Get latest jenkinsci/custom-distribution-service version
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "jenkinsci"
       repository: "custom-distribution-service"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      versionFilter:
+      versionfilter:
         kind: latest
 
 conditions:
   checkDockerImagePublished:
     name: Is latest jenkinsciinfra/custom-distribution-service docker image published
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/custom-distribution-service"
@@ -37,7 +37,7 @@ conditions:
 targets:
   updateChart:
     name: Update custom-distribution-service helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/custom-distribution-service
       key: image.tag
@@ -48,8 +48,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/custom-distribution-service.yaml
+++ b/updatecli/updatecli.d/custom-distribution-service.yaml
@@ -48,6 +48,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `custom-distribution-service` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/incrementals-publisher.yaml
@@ -1,4 +1,4 @@
-title: Bump `incremental-publisher` docker image and helm chart versions
+name: Bump `incremental-publisher` docker image and helm chart versions
 
 scms:
   default:
@@ -14,7 +14,7 @@ scms:
 
 sources:
   latestRelease:
-    kind: githubRelease
+    kind: githubrelease
     name: Get jenkins-infra/incrementals-publish latest version
     spec:
       owner: "jenkins-infra"
@@ -25,7 +25,7 @@ sources:
 conditions:
   checkDockerImagePublished:
     name: Test if jenkinsciinfra/incrementals-publisher docker image is published
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/incrementals-publisher"
@@ -34,7 +34,7 @@ conditions:
 targets:
   updateChart:
     name: Update incrementals-publisher helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/incrementals-publisher
       key: image.tag
@@ -45,8 +45,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/incrementals-publisher.yaml
@@ -45,6 +45,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `incrementals-publisher` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -1,4 +1,4 @@
-title: Bump `ldap` docker image digest and helm chart version
+name: Bump `ldap` docker image digest and helm chart version
 
 scms:
   default:
@@ -14,14 +14,14 @@ scms:
 
 sources:
   crond:
-    kind: dockerDigest
+    kind: dockerdigest
     name: "Get jenkinsciinfra/ldap:cron-latest docker image digest"
     spec:
       image: "jenkinsciinfra/ldap"
       tag: "cron-latest"
       architecture: "amd64"
   slapd:
-    kind: dockerDigest
+    kind: dockerdigest
     name: Get jenkinsciinfra/ldap:latest docker image digest
     spec:
       image: "jenkinsciinfra/ldap"
@@ -33,7 +33,7 @@ sources:
 targets:
   updateChartCrond:
     name: Update ldap (crond) helm chart
-    kind: helmChart
+    kind: helmchart
     sourceid: crond
     spec:
       name: charts/ldap
@@ -42,7 +42,7 @@ targets:
     scmid: default
   updateChartSlapd:
     name: Update ldap (slapd) helm chart
-    kind: helmChart
+    kind: helmchart
     sourceid: slapd
     spec:
       name: charts/ldap
@@ -54,9 +54,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartCrond
-      - updateChartSlapd
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -54,6 +54,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `ldap` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -54,7 +54,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump `ldap` docker image version to {{ source "latestRelease" }}
+    title: Bump `ldap` crond docker image to {{ source "crond" }} and `ldap` slapd docker image to {{ source "slapd" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -1,4 +1,4 @@
-title: Bump `mirrorbits` docker images version and helm chart version
+name: Bump `mirrorbits` docker images version and helm chart version
 
 scms:
   default:
@@ -15,23 +15,22 @@ scms:
 sources:
   latestMirrorbitsRelease:
     name: Get latest version of jenkinsciinfra/mirrorbits
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "jenkins-infra"
       repository: "docker-mirrorbits"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      branch: "{{ .github.branch }}"
   latestHttpdRelease:
     name: Get latest digest of the Docker Image for httpd, in version 2.4
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "httpd"
       tag: "2.4"
       architecture: "amd64"
   latestGeoIPRelease:
     name: Get latest version of GeoIP
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "maxmind"
       repository: "geoipupdate"
@@ -42,7 +41,7 @@ conditions:
   checkMirrorbitsDockerImagePublished:
     name: Ensure that the image "jenkinsciinfra/mirrorbits:<found_version>" is published on the DockerHub
     sourceid: latestMirrorbitsRelease
-    kind: dockerImage
+    kind: dockerimage
     spec:
       image: "jenkinsciinfra/mirrorbits"
       architecture: "amd64"
@@ -50,7 +49,7 @@ conditions:
   checkGeoIPDockerImagePublished:
     name: Ensure that the image "maxmindinc/geoipupdate:<found_version>" is published on the DockerHub
     sourceid: latestGeoIPRelease
-    kind: dockerImage
+    kind: dockerimage
     spec:
       image: "maxmindinc/geoipupdate"
       architecture: "amd64"
@@ -62,7 +61,7 @@ targets:
   updateMirrorbits:
     name: "Update mirrorbits docker image version"
     sourceid: latestMirrorbitsRelease
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/mirrorbits
       key: "image.mirrorbits.tag"
@@ -71,7 +70,7 @@ targets:
   updateHttpd:
     name: "Update httpd docker image version"
     sourceid: latestHttpdRelease
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/mirrorbits
       key: "image.files.tag"
@@ -79,7 +78,7 @@ targets:
   updateGeoIP:
     name: "Update maxmindinc/geoipupdate docker image version"
     sourceid: latestGeoIPRelease
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/mirrorbits
       key: "geoipupdate.image.tag"
@@ -89,10 +88,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateMirrorbits
-      - updateHttpd
-      - updateGeoIP
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -1,4 +1,4 @@
-title: Bump nginx:stable docker image version
+name: Bump nginx:stable docker image version
 
 scms:
   default:
@@ -20,21 +20,21 @@ scms:
 sources:
   latestRelease:
     name: Get latest stable version of nginx
-    kind: gitTag
+    kind: gittag
     scmid: nginxGithubMirror
     spec:
-      versionFilter:
+      versionfilter:
         kind: regex
         ## Nginx stable version have the minor digit as an even number
         pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
     transformers:
-      - trimPrefix: "release-"
-      - addSuffix: "-alpine"
+      - trimprefix: "release-"
+      - addsuffix: "-alpine"
 
 conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "nginx"
@@ -44,7 +44,7 @@ conditions:
 targets:
   updateJavadocChart:
     name: "Update nginx stable docker image version for javadoc chart"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/javadoc
       key: image.tag
@@ -52,7 +52,7 @@ targets:
     scmid: default
   updateJenkinsioChartEn:
     name: "Update nginx stable docker image version for jenkinsio chart (EN)"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/jenkinsio
       key: images.en.tag
@@ -60,7 +60,7 @@ targets:
     scmid: default
   updateJenkinsioChartZh:
     name: "Update nginx stable docker image version for jenkinsio chart (ZH)"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/jenkinsio
       key: images.zh.tag
@@ -68,7 +68,7 @@ targets:
     scmid: default
   updatePluginSiteChart:
     name: "Update nginx stable docker image version for plugin-site chart"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/plugin-site
       key: frontend.image.tag
@@ -76,7 +76,7 @@ targets:
     scmid: default
   updateReportsChart:
     name: "Update nginx stable docker image version for reports chart"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/reports
       key: image.tag
@@ -84,7 +84,7 @@ targets:
     scmid: default
   updateArtifactCachingProxy:
     name: "Update nginx stable docker image version for artifact-caching-proxy chart"
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/artifact-caching-proxy
       key: image.tag
@@ -95,13 +95,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateJavadocChart
-      - updateJenkinsioChartEn
-      - updateJenkinsioChartZh
-      - updatePluginSiteChart
-      - updateReportsChart
-      - updateArtifactCachingProxy
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -95,6 +95,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `nginx` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -1,0 +1,52 @@
+title: Bump plugin-health-scoring docker image version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestRelease:
+    kind: githubrelease
+    name: "Get latest jenkinsciinfra/plugin-health-scoring release"
+    spec:
+      owner: "jenkins-infra"
+      repository: "plugin-health-scoring"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkDockerImagePublished:
+    name: "Test jenkinsciinfra/plugin-health-scoring:<latest_version> docker image tag"
+    kind: dockerimage
+    spec:
+      image: "jenkinsciinfra/plugin-health-scoring"
+      ## Tag from source
+      architecture: amd64
+
+targets:
+  updateChart:
+    name: Update plugin-health-scoring helm chart
+    kind: helmchart
+    spec:
+      name: charts/plugin-health-scoring
+      key: image.tag
+      versionincrement: patch
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump plugin-health-scoring docker version to {{ source "latestRelease" }}
+    spec:
+      labels:
+        - dependencies
+        - plugin-health-scoring

--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -45,7 +45,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump plugin-health-scoring docker version to {{ source "latestRelease" }}
+    title: Bump `plugin-health-scoring` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -1,4 +1,4 @@
-title: Bump plugin-health-scoring docker image version
+name: Bump plugin-health-scoring docker image version
 
 scms:
   default:

--- a/updatecli/updatecli.d/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/plugin-site-issues.yaml
@@ -46,6 +46,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `plugin-site-issues` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/plugin-site-issues.yaml
@@ -1,4 +1,4 @@
-title: Bump `plugin-site-issues` docker image and helm chart versions
+name: Bump `plugin-site-issues` docker image and helm chart versions
 
 scms:
   default:
@@ -14,7 +14,7 @@ scms:
 
 sources:
   latestRelease:
-    kind: githubRelease
+    kind: githubrelease
     name: "Get latest jenkins-infra/docker-plugin-site-issues latest version"
     spec:
       owner: "jenkins-infra"
@@ -26,7 +26,7 @@ conditions:
   checkDockerImagePublished:
     name: |
       Test jenkinsciinfra/docker-plugin-site-issues:{{ source `latestRelease` }} docker image tag
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/plugin-site-issues"
@@ -35,7 +35,7 @@ conditions:
 targets:
   updateChart:
     name: Update rating helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/plugin-site-issues
       key: image.tag
@@ -46,8 +46,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/rating.yaml
+++ b/updatecli/updatecli.d/rating.yaml
@@ -1,4 +1,4 @@
-title: Bump `rating` docker image and helm chart versions
+name: Bump `rating` docker image and helm chart versions
 
 scms:
   default:
@@ -14,10 +14,9 @@ scms:
 
 sources:
   latestRelease:
-    kind: githubRelease
+    kind: githubrelease
     name: "Get latest jenkins-infra/rating release"
     spec:
-      name: Get jenkins-infra/rating latest version
       owner: "jenkins-infra"
       repository: "rating"
       token: "{{ requiredEnv .github.token }}"
@@ -27,7 +26,7 @@ conditions:
   checkDockerImagePublished:
     name: |
       Test jenkinsciinfra/rating:{{ source `latestRelease` }} docker image tag
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/rating"
@@ -36,7 +35,7 @@ conditions:
 targets:
   updateChart:
     name: Update rating helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/rating
       key: image.tag
@@ -47,8 +46,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/rating.yaml
+++ b/updatecli/updatecli.d/rating.yaml
@@ -46,6 +46,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `rating` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -37,7 +37,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump `uplink` docker image version to {{ source "latestRelease" }}
+    title: Bump `uplink` docker image version to {{ source "latestDigest" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -1,4 +1,4 @@
-title: Bump `uplink` docker image digest and helm chart version
+name: Bump `uplink` docker image digest and helm chart version
 
 scms:
   default:
@@ -14,7 +14,7 @@ scms:
 
 sources:
   latestDigest:
-    kind: dockerDigest
+    kind: dockerdigest
     name: "Get httdp docker image digest"
     spec:
       image: "jenkinsciinfra/uplink"
@@ -26,7 +26,7 @@ sources:
 targets:
   updateChart:
     name: Update uplink helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/uplink
       key: image.tag
@@ -37,8 +37,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -37,6 +37,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `uplink` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -45,6 +45,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `wiki` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -1,4 +1,4 @@
-title: Bump `wiki` docker image and helm chart versions
+name: Bump `wiki` docker image and helm chart versions
 
 scms:
   default:
@@ -14,10 +14,9 @@ scms:
 
 sources:
   latestRelease:
-    kind: githubRelease
+    kind: githubrelease
     name: "Get latest jenkins-infra/docker-confluence-data release"
     spec:
-      name: Get jenkins-infra/docker-confluence-data latest version
       owner: "jenkins-infra"
       repository: "docker-confluence-data"
       token: "{{ requiredEnv .github.token }}"
@@ -26,7 +25,7 @@ sources:
 conditions:
   checkDockerImagePublished:
     name: "Test jenkinsciinfra/wiki:<latest_version> docker image tag"
-    kind: dockerImage
+    kind: dockerimage
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/wiki"
@@ -35,7 +34,7 @@ conditions:
 targets:
   updateChart:
     name: Update wiki helm chart
-    kind: helmChart
+    kind: helmchart
     spec:
       name: charts/wiki
       key: image.tag
@@ -46,8 +45,6 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChart
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/kubernetes-management/pull/2934

- Add the docker image tag in the values of accountapp (now that it's "automatically built") + track it with updateclie (ref. https://github.com/jenkins-infra/helm-charts/issues/64)
- Track the new plugin-health-score 's Docker image tag with updatecli
- Update the updatecli manifests with some 0.33.x improved syntax