### PR TITLE
feat(artifact-caching-proxy): expose service.annotations

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.0.14
+version: 0.1.0

--- a/charts/artifact-caching-proxy/templates/service.yaml
+++ b/charts/artifact-caching-proxy/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "artifact-caching-proxy.fullname" . }}
   labels:
     {{- include "artifact-caching-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -31,6 +31,7 @@ service:
   type: ClusterIP
   # non root port
   port: 8080
+  annotations: {}
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
To be able to configure AWS NLB annotations