### PR TITLE
fix: mirrorbits updatecli pr.title

### DIFF
--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -88,6 +88,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
+    title: Bump `mirrorbits` docker images version and helm chart version
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -1,4 +1,4 @@
-name: Bump `mirrorbits` docker images version and helm chart version
+name: Bump `mirrorbits` docker images and helm chart versions
 
 scms:
   default:
@@ -88,7 +88,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump `mirrorbits` docker images version and helm chart version
+    title: Bump `mirrorbits` docker images and helm chart versions
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helm-charts/pull/231

> "[updatecli][githubrelease] Bump version to ✔"