### PR TITLE
fix: restore wiki 0.3.30 in the helm chart repo index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1612,6 +1612,16 @@ entries:
   wiki:
   - apiVersion: v2
     appVersion: 0.0.7
+    created: "2022-10-06T09:39:56.585680469Z"
+    description: A Helm chart for wiki static content
+    digest: 5c8ee3e7545361b41575b86b2e19da003b68a2ca47063697d307fcf306a9d8e6
+    name: wiki
+    type: application
+    urls:
+    - https://github.com/jenkins-infra/helm-charts/releases/download/wiki-0.3.30/wiki-0.3.30.tgz
+    version: 0.3.30
+  - apiVersion: v2
+    appVersion: 0.0.7
     created: "2022-10-05T18:55:03.473660048Z"
     description: A Helm chart for wiki static content
     digest: 013ec3b576605af699ef16c254719e225723d2a1224b63cefa046885b82c8132


### PR DESCRIPTION
There has been a race condition after the successive merge of #235 and #234, resulting in this commit where we can see only accountapp remained in the helm charts repo index.yaml: https://github.com/jenkins-infra/helm-charts/commit/5aca4f0e811ed4c0a10851637b828b731bc33e24