### PR TITLE
Accepts updates on phs with review

### DIFF
--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -47,6 +47,9 @@ pullrequests:
     scmid: default
     title: Bump `plugin-health-scoring` docker image version to {{ source "latestRelease" }}
     spec:
+      automerge: true
+      reviewers:
+        - alecharp
       labels:
         - dependencies
         - plugin-health-scoring


### PR DESCRIPTION
If we can get an automatic review request from `updatecli` (https://github.com/updatecli/updatecli/issues/925), this could speed up the process. 