### PR TITLE
chore(updatecli) fix manifests with dockerdigest in 0.36.x

### DIFF
--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -20,6 +20,8 @@ sources:
       image: "jenkinsciinfra/ldap"
       tag: "cron-latest"
       architecture: "amd64"
+    transformers:
+      - trimprefix: 'sha256:'
   slapd:
     kind: dockerdigest
     name: Get jenkinsciinfra/ldap:latest docker image digest
@@ -27,6 +29,8 @@ sources:
       image: "jenkinsciinfra/ldap"
       tag: "latest"
       architecture: "amd64"
+    transformers:
+      - trimprefix: 'sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -28,6 +28,8 @@ sources:
       image: "httpd"
       tag: "2.4"
       architecture: "amd64"
+    transformers:
+      - trimprefix: 'sha256:'
   latestGeoIPRelease:
     name: Get latest version of GeoIP
     kind: githubrelease

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -20,6 +20,8 @@ sources:
       image: "jenkinsciinfra/uplink"
       tag: "latest"
       architecture: "amd64"
+    transformers:
+      - trimprefix: 'sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 


### PR DESCRIPTION
Same context as https://github.com/jenkins-infra/jenkins-infra/pull/2439.

This PR ensures that the `sha256:  prefix is removed when retrieving dockerdigest