### PR TITLE
feat(artifact-caching-proxy): add response time to nginx logs

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.4.0
+version: 0.4.1

--- a/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
@@ -23,7 +23,7 @@ data:
         default_type  application/octet-stream;
 
         log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                          '$status $body_bytes_sent "$http_referer" '
+                          '$status $body_bytes_sent $request_time "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"';
 
         access_log  /var/log/nginx/access.log  main;


### PR DESCRIPTION
From https://jenkins.datadoghq.com/integrations/nginx

> Note: The default NGINX log format does not have a request response time.