### PR TITLE
fix(artifact-caching-proxy): always add annotations other than podAnnotations

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -12,13 +12,9 @@ spec:
       {{- include "artifact-caching-proxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-        {{- if .Values.template.mountConfigMap }}
         checksum/default-config: {{ include (print $.Template.BasePath "/nginx-default-configmap.yaml") . | sha256sum }}
         checksum/proxy-config: {{ include (print $.Template.BasePath "/nginx-proxy-configmap.yaml") . | sha256sum }}
-        {{- end }}
         # metrics collection with Datadog
         ad.datadoghq.com/{{ .Chart.Name }}.checks: |
           {
@@ -35,7 +31,9 @@ spec:
         # log collection with Datadog
         ad.datadoghq.com/{{ .Chart.Name }}.logs: {{ .Values.logCollection.config }}
         {{- end }}
-      {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "artifact-caching-proxy.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
The additional ones were never declared.