### PR TITLE
fix(artifact-caching-proxy): single quote around values.logCollectionconfig

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
           }
         {{- if .Values.logCollection.enabled }}
         # log collection with Datadog
-        ad.datadoghq.com/{{ .Chart.Name }}.logs: {{ .Values.logCollection.config }}
+        ad.datadoghq.com/{{ .Chart.Name }}.logs: {{ .Values.logCollection.config | squote }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The single quotes present in the values.yaml are lost when applied in the statefulset, rendering this value recognized as an array instead of a string.