### PR TITLE
fix(artifact-caching-proxy): fix datadog logs annotation format

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -61,7 +61,7 @@ resources: {}
 # log collection with Datadog
 logCollection:
   enabled: true
-  config: '[{"source":"nginx","service":"artifact-caching-proxy", "tags": "env:prod"}]'
+  config: '[{"source":"nginx","service":"artifact-caching-proxy","tag": "env:prod"}]'
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
Fix datadog agent log error 'Invalid configuration for service: could not parse kubernetes annotation'