### PR TITLE
feat(plugin-health-scoring): allow specific readiness and liveness probe paths

### DIFF
--- a/charts/plugin-health-scoring/Chart.yaml
+++ b/charts/plugin-health-scoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: plugin-health-scoring
 type: application
-version: 1.2.7
+version: 1.3.0

--- a/charts/plugin-health-scoring/templates/deployment.yaml
+++ b/charts/plugin-health-scoring/templates/deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /actuator/health/readiness
+              path: {{ .Values.probes.readiness | default .Values.probes.path  }}
               port: http
           livenessProbe:
             httpGet:
-              path: /actuator/health/liveness
+              path: {{ .Values.probes.liveness | default .Values.probes.path  }}
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/plugin-health-scoring/templates/deployment.yaml
+++ b/charts/plugin-health-scoring/templates/deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: {{ .Values.probes.path }}
+              path: /actuator/health/readiness
               port: http
           livenessProbe:
             httpGet:
-              path: {{ .Values.probes.path }}
+              path: /actuator/health/liveness
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/plugin-health-scoring/templates/deployment.yaml
+++ b/charts/plugin-health-scoring/templates/deployment.yaml
@@ -35,11 +35,11 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: {{ .Values.probes.readiness | default .Values.probes.path  }}
+              path: {{ .Values.probes.readinessPath | default .Values.probes.path }}
               port: http
           livenessProbe:
             httpGet:
-              path: {{ .Values.probes.liveness | default .Values.probes.path  }}
+              path: {{ .Values.probes.livenessPath | default .Values.probes.path }}
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -45,8 +45,6 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
-probes:
-  path: /actuator/health
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -49,8 +49,9 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 probes:
-  readiness: /actuator/health/readiness
-  liveness: /actuator/health/liveness
+  path: /actuator/health
+  readinessPath: /actuator/health/readiness
+  livenessPath: /actuator/health/liveness
 config:
   ucCron: "0 */15 * * * *"
   peCron: "0 10 * * * *"

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -49,8 +49,8 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 config:
-  ucCron: "* */15 * * * *"
-  peCron: "* 10 * * * *"
+  ucCron: "0 */15 * * * *"
+  peCron: "0 10 * * * *"
   githubOauth: s3cr3t
 database:
   username: plugin-health-scoring

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -48,6 +48,9 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+probes:
+  readiness: /actuator/health/readiness
+  liveness: /actuator/health/liveness
 config:
   ucCron: "0 */15 * * * *"
   peCron: "0 10 * * * *"


### PR DESCRIPTION
Readiness and Liveness have two different endpoints offered by `actuator`.