### PR TITLE
Upgrade Plugin Health Scoring from 1.4.0 to 1.4.1

### DIFF
--- a/charts/plugin-health-scoring/Chart.yaml
+++ b/charts/plugin-health-scoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: plugin-health-scoring
 type: application
-version: 1.4.1
+version: 1.4.2

--- a/charts/plugin-health-scoring/tests/custom_values_test.yaml
+++ b/charts/plugin-health-scoring/tests/custom_values_test.yaml
@@ -39,5 +39,5 @@ tests:
         template: secret.yaml
       - equal:
           path: spec.template.metadata.annotations.checksum/config
-          value: 58c01dc5e08c7da8a5ee44574bdc38dea8966a1284ebbb19a40aac5017fa6239 # Any change to secret.yaml will need to regenerate this checksum
+          value: de200f959b2a6995b0bce9bfe51dc858bfb43c49cea86c3efd40f725a9ed3255 # Any change to secret.yaml will need to regenerate this checksum
         template: deployment.yaml

--- a/charts/plugin-health-scoring/tests/defaults_test.yaml
+++ b/charts/plugin-health-scoring/tests/defaults_test.yaml
@@ -56,7 +56,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.metadata.annotations.checksum/config
-          value: 5f98b97aee063de948038e1917915e1fa84be48a5976863d45863627e51b9b9f # Any change to secret.yaml will need to regenerate this checksum
+          value: 1f80fe50398936bc7d62c2f2654fb97ceca2d8de49f5c307c6feaf8a4fd3731a # Any change to secret.yaml will need to regenerate this checksum
         template: deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: "jenkinsciinfra/plugin-health-scoring"
   pullPolicy: IfNotPresent
-  tag: "v1.4.0"
+  tag: "v1.4.1"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This is to deploy the backport of https://github.com/jenkins-infra/plugin-health-scoring/pull/169