### PR TITLE
fix(acp): Correct ACP Nginx setup to fix HTTP/502 errors

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.5.0
+version: 0.5.1

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -43,7 +43,7 @@ data:
 
         location / {
             proxy_cache         nginx_cache;
-            proxy_pass          {{ .Values.proxy.proxyPass }}/;
+            proxy_pass          {{ .Values.proxy.proxyPass }}$request_uri;
             #proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
             proxy_cache_valid {{ .Values.proxy.proxyCacheValidCode }} {{ .Values.proxy.proxyCacheValidCodeDuration }};
             proxy_cache_valid any {{ .Values.proxy.proxyCacheValidAnyDuration }};

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -22,14 +22,10 @@ data:
         chunked_transfer_encoding on;
         client_max_body_size 0;
 
-        proxy_set_header    X-Artifactory-Override-Base-Url $http_x_forwarded_proto://$host:$server_port/;
-        proxy_set_header    X-Forwarded-Port  $server_port;
-        proxy_set_header    X-Forwarded-Proto $http_x_forwarded_proto;
-        #proxy_set_header    Host              $http_host;
-        proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
-
         add_header          X-Cache-Status    $upstream_cache_status;
 
+        # Ensure that no authentication header are forwarded to the upstream
+        proxy_set_header    Authorization     "";
         proxy_read_timeout  900;
         proxy_pass_header   Server;
         proxy_cookie_path   ~*^/.* /;


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2322

This PR fixes the ACP which are currently responding with HTTP/502.

It introduces the following changes:

- Use the `$request_uri` in the `proxy_pass` directive to  ensure that requested URL are forwarded to the remote upstream
- Make sure that no `Authorization` header is forwarded by cleaning it up (otherwise JFrog answers HTTP/401)
