### PR TITLE
feat(acp) improve access logs

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.5.1
+version: 0.6.0

--- a/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
@@ -24,7 +24,8 @@ data:
 
         log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent $request_time "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for"';
+                          '"$http_user_agent" "$http_x_forwarded_for"'
+                          '"$upstream_addr" "$upstream_status" "$upstream_response_time"';
 
         access_log  /var/log/nginx/access.log  main;
 

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -55,6 +55,9 @@ data:
 
       location /nginx_status {
         stub_status on;
+
+        # Avoid verbose access log
+        access_log      off;
       }
 
       location / {

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -17,8 +17,6 @@ data:
             set $http_x_forwarded_proto  $scheme;
         }
 
-        # rewrite ^/$ /webapp/ redirect;
-        # rewrite ^/?(/)?$ /webapp/ redirect;
         chunked_transfer_encoding on;
         client_max_body_size 0;
 

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -32,8 +32,10 @@ data:
             proxy_pass          {{ .Values.proxy.proxyPass }};
         }
 
+        # Endpoint used to check healthiness of the service before running Maven commands in Jenkins pipelines
         location {{ .Values.ingress.healthPath }} {
             auth_basic      off;
+            # Avoid verbose access log
             access_log      off;
             allow           all;
             return          200 'OK';
@@ -48,6 +50,7 @@ data:
         }
     }
   status.conf: |
+    # Vhost used by datadog to collect custom Nginx metrics
     server {
       listen {{ .Values.service.statusPort }};
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2322

Depends on #396

This PR improves the log management for the ACP proxy:

- Adds upstream related fields in access log to help diagnosing behavior
- Do not log request to nginx status (datadog) or health endpoint (pipeline library and probes)
- (chore) Add explanatory comments while we're there