### PR TITLE
feat(acp) add SNAPSHOT artefacts to caching

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.6.0
+version: 0.7.0

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -28,7 +28,7 @@ data:
         proxy_pass_header   Server;
         proxy_cookie_path   ~*^/.* /;
 
-        location ~* (maven-metadata.xml|SNAPSHOT) {
+        location ~* (maven-metadata.xml) {
             proxy_pass          {{ .Values.proxy.proxyPass }};
         }
 


### PR DESCRIPTION
This PR adds the SNAPSHOTS URLs (from our infra to https://repo.jenkins-ci.org/*SNAPSHOT*) in the cached items.

As pointed by @jglick a few weeks ago, this should be fine since SNAPSHOTS have unique names.