### PR TITLE
fix(GHA): add GITHUB_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: install helm unittests
-        with:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           helm env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,6 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Generate token
-        uses: tibdex/github-app-token@v1.7
-        id: generate_token
-        with:
-          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
-          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -35,6 +28,8 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: install helm unittests
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           helm env
           helm plugin install https://github.com/quintush/helm-unittest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,13 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1.7
+        id: generate_token
+        with:
+          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
+          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
+
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
I've noticed this warning on actions, which are (too) frequently failing to download helm-unittest:

<img width="1877" alt="image" src="https://user-images.githubusercontent.com/91831478/214519638-7cf3e6b2-81f3-4881-a21c-d7f5fd5c7d37.png">
