### PR TITLE
chore(gha) Fix helm plugin network errors and helm setup action warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,10 @@ jobs:
       - name: install helm unittests
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest
-          # Repeat to fight against network errors in  GHA runners
-          helm plugin install https://github.com/quintush/helm-unittest
+          # Repeat 3 times to fight against network errors in  GHA runners
+          helm plugin install https://github.com/quintush/helm-unittest \
+            || helm plugin install https://github.com/quintush/helm-unittest \
+            || helm plugin install https://github.com/quintush/helm-unittest
 
       - name: run unit tests
         working-directory: ./charts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+      - name: Get Tools Versions
+        id: tools-versions
+        run: |
+          current_helm_version="$(curl --silent --location https://raw.githubusercontent.com/jenkins-infra/docker-helmfile/main/Dockerfile  | grep 'ARG' | grep 'HELM_VERSION=' | sort -u | cut -d'=' -f2)"
+          echo "CURRENT_HELM_VERSION=${current_helm_version}" >> $GITHUB_OUTPUT
       - name: Set up Helm
         uses: azure/setup-helm@v3
+        with:
+          version: "${{ steps.tools-versions.outputs.CURRENT_HELM_VERSION }}"
 
       - name: install helm unittests
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           helm env
+          helm plugin install https://github.com/quintush/helm-unittest
+          # Repeat to fight against network errors in  GHA runners
           helm plugin install https://github.com/quintush/helm-unittest
 
       - name: run unit tests


### PR DESCRIPTION
Fixup of #402 

- Warning in #402 's body comes from the `azure/setup-helm` (ref. https://github.com/Azure/setup-helm#example). By specifying a given version (extracted from our Docker Image principal branch with a dummy `curl | grep`), no need for token anymore
- Trying to solve the "helm plugin install" network error by using @lemeurherve 's trick of ... retrying a 2nd time "to be sure".