### PR TITLE
chore(artifact-caching-proxy): change the default health check path

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.8.1
+version: 0.9.0

--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.8.0
+version: 0.8.1

--- a/charts/artifact-caching-proxy/templates/ingress-health.yaml
+++ b/charts/artifact-caching-proxy/templates/ingress-health.yaml
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-healthz
+  name: {{ $fullName }}-health
   labels:
     {{- include "artifact-caching-proxy.labels" . | nindent 4 }}
   {{- if or .Values.auth.enabled .Values.ingress.annotations }}

--- a/charts/artifact-caching-proxy/templates/ingress-health.yaml
+++ b/charts/artifact-caching-proxy/templates/ingress-health.yaml
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-health
+  name: {{ $fullName }}-healthcheck
   labels:
     {{- include "artifact-caching-proxy.labels" . | nindent 4 }}
   {{- if or .Values.auth.enabled .Values.ingress.annotations }}

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -1,0 +1,22 @@
+suite: Tests with custom values
+templates:
+  - ingress-health.yaml
+tests:
+  - it: Should set a custom health check path when specified by values
+    template: ingress-health.yaml
+    set:
+      ingress:
+        enabled: true
+        healthPath: "la-cite-de-la-peur"
+        healthPathType: "fait-peur"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: "la-cite-de-la-peur"
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: "fait-peur"

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -1,12 +1,32 @@
 suite: default tests
 templates:
   - ingress.yaml
+  - ingress-health.yaml
 tests:
   - it: should not generate any ingress with default values
+    template: ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not generate any ingress with default values
+    template: ingress-health.yaml
     asserts:
       - hasDocuments:
           count: 0
   - it: "should generate an ingress without any annotation"
+    template: ingress.yaml
+    set:
+      ingress:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isNull:
+          path: metadata.annotations
+  - it: "should generate an ingress without any annotation"
+    template: ingress-health.yaml
     set:
       ingress:
         enabled: true
@@ -18,6 +38,7 @@ tests:
       - isNull:
           path: metadata.annotations
   - it: "should generate an ingress with auth annotations"
+    template: ingress.yaml
     set:
       ingress:
         enabled: true
@@ -35,7 +56,40 @@ tests:
           value:
             nginx.ingress.kubernetes.io/auth-secret: RELEASE-NAME-artifact-caching-proxy-basic-auth
             nginx.ingress.kubernetes.io/auth-type: basic
+  - it: "should generate an ingress with auth annotations"
+    template: ingress-health.yaml
+    set:
+      ingress:
+        enabled: true
+      auth:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isNull:
+          path: metadata.annotations
   - it: "should generate an ingress with custom annotations"
+    template: ingress.yaml
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          a-custom/annotation: "hello world"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isNotNull:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            a-custom/annotation: "hello world"
+  - it: "should generate an ingress with custom annotations"
+    template: ingress-health.yaml
     set:
       ingress:
         enabled: true
@@ -53,6 +107,7 @@ tests:
           value:
             a-custom/annotation: "hello world"
   - it: "should generate an ingress with auth and custom annotations"
+    template: ingress.yaml
     set:
       ingress:
         enabled: true
@@ -73,3 +128,23 @@ tests:
             a-custom/annotation: "hello world"
             nginx.ingress.kubernetes.io/auth-secret: RELEASE-NAME-artifact-caching-proxy-basic-auth
             nginx.ingress.kubernetes.io/auth-type: basic
+  - it: "should generate an ingress with auth and custom annotations"
+    template: ingress-health.yaml
+    set:
+      ingress:
+        enabled: true
+        annotations:
+          a-custom/annotation: "hello world"
+      auth:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isNotNull:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            a-custom/annotation: "hello world"

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -40,7 +40,7 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  healthPath: /healthz
+  healthPath: /health
   healthPathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/3537