### PR TITLE
fix(artifact-caching-proxy): correct nginx log format

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.10.0
+version: 0.10.1

--- a/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
@@ -24,7 +24,7 @@ data:
 
         log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent $request_time "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for"'
+                          '"$http_user_agent" "$http_x_forwarded_for" '
                           '"$upstream_addr" "$upstream_status" "$upstream_response_time"';
 
         access_log  /var/log/nginx/access.log  main;


### PR DESCRIPTION
to avoid a double double quotes