### PR TITLE
chore(artifact-caching-proxy): increase default cache retention to one month

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.10.2
+version: 0.10.3

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -85,9 +85,9 @@ cache:
   # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path
   path: /data/nginx-cache
   keysZoneSize: "200m"
-  inactive: "24h"
+  inactive: "1M"
   useTempPath: "off"
 proxy:
   proxyPass: "repo.jenkins-ci.org"
   proxyCacheValidCode: "200 206"
-  proxyCacheValidCodeDuration: "24h"
+  proxyCacheValidCodeDuration: "1M"


### PR DESCRIPTION
As we're caching versioned jar which don't change, we can increase the cache retention time.

(edit by dduportal for gh auto links) Ref. https://github.com/jenkins-infra/helpdesk/issues/2752