### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Release Charts
-
 on:
   push:
     branches:
       - main
     paths:
       - 'charts/**'
-
 # Only allow 1 release at a time (avoid concurent deployment to gh-pages)
 concurrency: "release-chart"
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -18,16 +15,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Install Helm
-        uses: azure/setup-helm@v3
-
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sync-readme.yaml
+++ b/.github/workflows/sync-readme.yaml
@@ -1,5 +1,4 @@
 name: Sync README to gh-pages
-
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,11 @@
----
 name: Test Charts
-
 on:
   push:
   pull_request:
   workflow_dispatch:
-
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         chart:
@@ -19,7 +15,6 @@ jobs:
           - jenkins-kubernetes-agents
           - plugin-health-scoring
       fail-fast: false
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,10 +24,9 @@ jobs:
           current_helm_version="$(curl --silent --location https://raw.githubusercontent.com/jenkins-infra/docker-helmfile/main/Dockerfile  | grep 'ARG' | grep 'HELM_VERSION=' | sort -u | cut -d'=' -f2)"
           echo "CURRENT_HELM_VERSION=${current_helm_version}" >> $GITHUB_OUTPUT
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: "${{ steps.tools-versions.outputs.CURRENT_HELM_VERSION }}"
-
       - name: install helm unittests
         run: |
           helm env
@@ -43,7 +37,6 @@ jobs:
             || true
           # Fail if not installed
           helm plugin list | grep unittest
-
       - name: run unit tests
         working-directory: ./charts/
         run: |


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402