### PR TITLE
Bump Plugin Health Scoring from 1.8.0 to 1.9.0

### DIFF
--- a/charts/plugin-health-scoring/Chart.yaml
+++ b/charts/plugin-health-scoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: plugin-health-scoring
 type: application
-version: 2.0.6
+version: 2.0.7

--- a/charts/plugin-health-scoring/values.yaml
+++ b/charts/plugin-health-scoring/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: "jenkinsciinfra/plugin-health-scoring"
   pullPolicy: IfNotPresent
-  tag: "v1.8.0"
+  tag: "v1.9.0"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
In place of #438 without the indentation modifications.