### PR TITLE
chore(acp): bump chart version

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.10.3
+version: 0.10.4


### PR DESCRIPTION
First release run failed with:

![image](https://user-images.githubusercontent.com/91831478/229741116-9c7873a3-a205-433b-ae34-97c61b8ffaa7.png)

(https://github.com/jenkins-infra/helm-charts/actions/runs/4605841335)

Second one triggered manually failed as the chart version already existed, hence this bump.