### PR TITLE
chore(tests) switch from quintush to helm-unittest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,16 @@ jobs:
         with:
           version: "${{ steps.tools-versions.outputs.CURRENT_HELM_VERSION }}"
       - name: install helm unittests
+        env:
+          HELM_UNITTESTS_URL: https://github.com/helm-unittest/helm-unittest
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest
+          # Repeat 2 times to fight against network errors in  GHA runners
+          # Always return true
+          helm plugin install "$HELM_UNITTESTS_URL" \
+            || helm plugin install "$HELM_UNITTESTS_URL" \
+            || true
+          # Fail if not installed
           helm plugin list | grep unittest
       - name: run unit tests
         working-directory: ./charts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,12 @@ jobs:
         with:
           version: "${{ steps.tools-versions.outputs.CURRENT_HELM_VERSION }}"
       - name: install helm unittests
-        env:
-          HELM_UNITTESTS_URL: https://github.com/helm-unittest/helm-unittest
         run: |
           helm env
           # Repeat 2 times to fight against network errors in  GHA runners
           # Always return true
-          helm plugin install "$HELM_UNITTESTS_URL" \
-            || helm plugin install "$HELM_UNITTESTS_URL" \
+          helm plugin install https://github.com/helm-unittest/helm-unittest \
+            || helm plugin install https://github.com/helm-unittest/helm-unittest \
             || true
           # Fail if not installed
           helm plugin list | grep unittest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,9 @@ jobs:
       - name: install helm unittests
         run: |
           helm env
-          # Repeat 2 times to fight against network errors in  GHA runners
-          # Always return true
-          helm plugin install https://github.com/quintush/helm-unittest \
-            || helm plugin install https://github.com/quintush/helm-unittest \
-            || true
-          # Fail if not installed
+          helm plugin install https://github.com/quintush/helm-unittest
           helm plugin list | grep unittest
       - name: run unit tests
         working-directory: ./charts/
         run: |
-          helm unittest --helm3 "${{ matrix.chart }}"
+          helm unittest "${{ matrix.chart }}"

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -22,6 +22,6 @@ tests:
       - isKind:
           of: ConfigMap
       - isNotNull:
-          path: data.vhost-proxy\.conf
+          path: data["vhost-proxy.conf"]
       - isNotNull:
-          path: data.vhost-status\.conf
+          path: data["vhost-status.conf"]

--- a/charts/httpredirector/tests/defaults_test.yaml
+++ b/charts/httpredirector/tests/defaults_test.yaml
@@ -13,13 +13,13 @@ tests:
           # The release name, default to "RELEASE-NAME" within helm-unittest
           value: RELEASE-NAME-localhost
       - equal:
-          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect]
+          path: metadata.annotations["nginx.ingress.kubernetes.io/permanent-redirect"]
           value: "http://demo.localhost.me"
       - equal:
-          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect-code]
+          path: metadata.annotations["nginx.ingress.kubernetes.io/permanent-redirect-code"]
           value: "308"
       - equal:
-          path: metadata.annotations.[cert-manager.io/cluster-issuer]
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
           value: "letsencrypt-prod"
       - equal:
           path: spec.rules[0].host

--- a/charts/httpredirector/tests/withvalues_test.yaml
+++ b/charts/httpredirector/tests/withvalues_test.yaml
@@ -18,10 +18,10 @@ tests:
           # The release name, default to "RELEASE-NAME" within helm-unittest
           value: RELEASE-NAME-domain
       - equal:
-          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect]
+          path: metadata.annotations["nginx.ingress.kubernetes.io/permanent-redirect"]
           value: "http://my.domain.com"
       - equal:
-          path: metadata.annotations.[nginx.ingress.kubernetes.io/permanent-redirect-code]
+          path: metadata.annotations["nginx.ingress.kubernetes.io/permanent-redirect-code"]
           value: "308"
       - equal:
           path: spec.rules[0].host

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -1,4 +1,4 @@
-suite: default tests
+suite: credentials tests
 templates:
   - jcasc-jobs-config.yaml
 tests:
@@ -57,7 +57,7 @@ tests:
               stsTokenDuration: 300
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >

--- a/charts/jenkins-jobs/tests/defaults_test.yaml
+++ b/charts/jenkins-jobs/tests/defaults_test.yaml
@@ -25,7 +25,7 @@ tests:
           path: metadata.labels.jenkins-jenkins-config
           value: "true"
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -53,7 +53,7 @@ tests:
           path: metadata.labels.jenkins-jenkins-config
           value: "true"
       - equal:
-          path: data.custom-config\.yaml
+          path: data["custom-config.yaml"]
           value: |-
             jobs:
               - script: >
@@ -81,7 +81,7 @@ tests:
           path: metadata.labels.admin-controller-jenkins-config
           value: "true"
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -1,4 +1,4 @@
-suite: default tests
+suite: folder tests
 templates:
   - jcasc-jobs-config.yaml
 tests:
@@ -10,7 +10,7 @@ tests:
           kind: folder
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -27,7 +27,7 @@ tests:
           kind: folder
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -53,7 +53,7 @@ tests:
               kind: folder
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -82,7 +82,7 @@ tests:
               name: Child Multibranch Job
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -1,4 +1,4 @@
-suite: default tests
+suite: multibranch jobs tests
 templates:
   - jcasc-jobs-config.yaml
 tests:
@@ -17,7 +17,7 @@ tests:
           name: Default Job
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -124,7 +124,7 @@ tests:
           kind: multibranchPipelineJob
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -234,7 +234,7 @@ tests:
           githubCredentialsId: the-force
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >
@@ -344,7 +344,7 @@ tests:
           branchIncludes: "prod dev MR-*"
     asserts:
       - equal:
-          path: data.jobs-definition\.yaml
+          path: data["jobs-definition.yaml"]
           value: |-
             jobs:
               - script: >


### PR DESCRIPTION
This PR fixes the builds failure, during the unit tests steps, with the `unknown flag: --helm3` error (https://github.com/jenkins-infra/helm-charts/actions/runs/4675170591/jobs/8280015667?pr=480).

It appears that `quintush` has switched back (or was granted maintenership) on https://github.com/helm-unittest/helm-unittest as per https://github.com/quintush/helm-unittest/issues/124.

A commit was added to update the YAML manifest syntax to fulfill the new JsonPath module introduced in https://github.com/helm-unittest/helm-unittest/releases/tag/v0.3.0