### PR TITLE
feat(jenkins-kubernetes-agents) add an SVC account token (no longer generated since Kubernetes 1.23)

### DIFF
--- a/charts/jenkins-kubernetes-agents/Chart.yaml
+++ b/charts/jenkins-kubernetes-agents/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: jenkins-kubernetes-agents
 description: A Helm chart for using Jenkins Kubernetes agents on a remote cluster
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.1.0"

--- a/charts/jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml
+++ b/charts/jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.existingServiceAccount }}
+# From https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "jenkins.serviceAccountName" . }}-token
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "jenkins.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
+++ b/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
@@ -34,6 +34,28 @@ tests:
       - equal:
           path: metadata.namespace
           value: tatooine
+  - it: Should create a token for the the service account 'jenkins-agent' in the provided namespace
+    template: serviceaccounttoken.yaml
+    release:
+      namespace: tatooine
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: jenkins-agent-token
+      - equal:
+          path: type
+          value: kubernetes.io/service-account-token
+      - equal:
+          path: metadata.namespace
+          value: tatooine
+      - equal:
+          path: metadata.annotations["kubernetes.io/service-account.name"]
+          value: jenkins-agent
+
 
   - it: Should create the default Role 'jenkins-agent-role' in the provided namespace
     template: rbac.yaml

--- a/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
+++ b/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
@@ -56,7 +56,6 @@ tests:
           path: metadata.annotations["kubernetes.io/service-account.name"]
           value: jenkins-agent
 
-
   - it: Should create the default Role 'jenkins-agent-role' in the provided namespace
     template: rbac.yaml
     release:

--- a/charts/jenkins-kubernetes-agents/tests/defaults_test.yaml
+++ b/charts/jenkins-kubernetes-agents/tests/defaults_test.yaml
@@ -3,6 +3,7 @@ templates:
   - rbac.yaml
   - resourcequota.yaml
   - serviceaccount.yaml
+  - serviceaccounttoken.yaml
 tests:
   - it: Should not create any quotas by default
     template: resourcequota.yaml
@@ -23,6 +24,26 @@ tests:
       - equal:
           path: metadata.namespace
           value: NAMESPACE
+
+  - it: Should create a token for the the service account 'jenkins-agent' in the provided namespace
+    template: serviceaccounttoken.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: jenkins-agent-token
+      - equal:
+          path: type
+          value: kubernetes.io/service-account-token
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: metadata.annotations["kubernetes.io/service-account.name"]
+          value: jenkins-agent
 
   - it: Should create the default Role 'jenkins-agent-role' in the provided namespace
     template: rbac.yaml


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3521, I stumbled upon this change in Kubernetes 1.23

This PR ensures that an API token for the `jenkins-agent` SVC account is created: https://v1-24.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token.

- SVC accounts created before Kubernetes 1.23 keep their existing token (it's the case for `cik8s`'s `jenkins-agents/jenkins-agent` SVC account)
- If a custom SVC account is specified, then no token is created

Validated with the following:
- Unit tests (of course)
- Verified with local `helmfile diff` commands:
  - `jenkins-agents` and `jenkins-agents-bom` releases in `cik8s` cluster: new secret created for each. The former secret for `jenkins-agents/jenkins-agent` is not removed (it has a unique name)
  - `jenkins-release-agents` and `jenkins-infra-agents` in `privatek8s` cluster: no changes