### PR TITLE
fix(accountapp): quote `smtp.port` value

### DIFF
--- a/charts/accountapp/Chart.yaml
+++ b/charts/accountapp/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for accounts.jenkins.io
 maintainers:
 - name: timja
 name: accountapp
-version: 0.4.0
+version: 0.4.1

--- a/charts/accountapp/templates/deployment.yaml
+++ b/charts/accountapp/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: SMTP_SERVER
               value: {{ .Values.smtp.server }}
             - name: SMTP_PORT
-              value: {{ .Values.smtp.port }}
+              value: {{ .Values.smtp.port | quote }}
             - name: SMTP_USER
               value: {{ .Values.smtp.user }}
             - name: APP_URL


### PR DESCRIPTION
Ad quotes around smtp.port value to avoid the error `json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`