### PR TITLE
feat(accountapp): allow configuring the sender email address value

### DIFF
--- a/charts/accountapp/Chart.yaml
+++ b/charts/accountapp/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for accounts.jenkins.io
 maintainers:
 - name: timja
 name: accountapp
-version: 0.4.1
+version: 0.5.0

--- a/charts/accountapp/templates/deployment.yaml
+++ b/charts/accountapp/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: {{ .Values.smtp.auth | quote }}
             - name: SMTP_SERVER
               value: {{ .Values.smtp.server }}
+            - name: SMTP_SENDER
+              value: {{ .Values.smtp.sender }}
             - name: SMTP_PORT
               value: {{ .Values.smtp.port | quote }}
             - name: SMTP_USER

--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: jenkinsciinfra/account-app
-  tag: 0.3.5
+  tag: 0.4.1
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -58,6 +58,7 @@ seniority: 12
 smtp:
   auth: true
   server: smtp.sendgrid.net
+  sender: admin@jenkins-ci.org
   port: 25
   user:
   password:

--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -59,7 +59,7 @@ smtp:
   auth: true
   server: smtp.sendgrid.net
   sender: admin@jenkins-ci.org
-  port: 25
+  port: 587
   user:
   password:
 appUrl: https://accounts.jenkins.io


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/account-app/pull/264

Also set the default SMTP port to 587 as the auth is activated, to respect the default behaviour of the app prior to https://github.com/jenkins-infra/account-app/pull/265