### PR TITLE
fix(jenkins-kubernetes-agents): add missing templates in the custom value unit test

### DIFF
--- a/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
+++ b/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
@@ -3,6 +3,8 @@ templates:
   - serviceaccount.yaml
   - rbac.yaml
   - resourcequota.yaml
+  - serviceaccount.yaml
+  - serviceaccounttoken.yaml
 tests:
   - it: Should set a quota of maximum 30 pods when specified by values
     template: resourcequota.yaml


### PR DESCRIPTION
Fix the following error seen recently on PRs, ex: https://github.com/jenkins-infra/helm-charts/actions/runs/5055580244/jobs/9071961236

```
 FAIL  Tests with custom values	jenkins-kubernetes-agents/tests/custom_values_test.yaml
	- Should create a token for the the service account 'jenkins-agent' in the provided namespace

		- asserts[0] `hasDocuments` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

		- asserts[1] `isKind` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

		- asserts[2] `equal` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

		- asserts[3] `equal` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

		- asserts[4] `equal` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

		- asserts[5] `equal` fail
			Error:
				template "jenkins-kubernetes-agents/templates/serviceaccounttoken.yaml" not exists or not selected in test suite

 PASS  Tests with default values	jenkins-kubernetes-agents/tests/defaults_test.yaml
```

This error comes from the fact that now (since 2 days) the `unittest` Helm plugin ensures that only specified templates are loaded: https://github.com/helm-unittest/helm-unittest/releases/tag/v0.3.3
> Fix template filter, to only load templates that are defined

The following PR pins its version to avoid bad surprises like this in the future: #513 