### PR TITLE
fix: pin `unittest` helm plugin version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+env:
+  UNITTEST_VERSION: v0.3.2
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -32,9 +34,8 @@ jobs:
           helm env
           # Repeat 2 times to fight against network errors in  GHA runners
           # Always return true
-          unittest_version="v0.3.2"
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${unittest_version} \
-            || helm plugin install https://github.com/helm-unittest/helm-unittest --version ${unittest_version} \
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${UNITTEST_VERSION} \
+            || helm plugin install https://github.com/helm-unittest/helm-unittest --version ${UNITTEST_VERSION} \
             || true
           # Fail if not installed
           helm plugin list | grep unittest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,9 @@ jobs:
           helm env
           # Repeat 2 times to fight against network errors in  GHA runners
           # Always return true
-          helm plugin install https://github.com/helm-unittest/helm-unittest \
-            || helm plugin install https://github.com/helm-unittest/helm-unittest \
+          unittest_version="v0.3.2"
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${unittest_version} \
+            || helm plugin install https://github.com/helm-unittest/helm-unittest --version ${unittest_version} \
             || true
           # Fail if not installed
           helm plugin list | grep unittest

--- a/updatecli/updatecli.d/helm-unittest.yaml
+++ b/updatecli/updatecli.d/helm-unittest.yaml
@@ -25,13 +25,11 @@ sources:
 targets:
   updateChart:
     name: Update helm-unittest version in the GitHub Action workflow
-    kind: file
+    kind: yaml
     scmid: default
     spec:
-      matchpattern: >
-        unittest_version=(.*)
-      replacepattern: >
-        unittest_version={{ source "latestRelease" }}
+      file: .github/workflows/test.yml
+      key: env.UNITTEST_VERSION
 
 actions:
   default:

--- a/updatecli/updatecli.d/helm-unittest.yaml
+++ b/updatecli/updatecli.d/helm-unittest.yaml
@@ -1,0 +1,44 @@
+name: Bump `helm-unittest` helm plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestRelease:
+    kind: githubrelease
+    name: "Get latest helm-unittest/helm-unittest release"
+    spec:
+      owner: "helm-unittest"
+      repository: "helm-unittest"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+targets:
+  updateChart:
+    name: Update helm-unittest version in the GitHub Action workflow
+    kind: file
+    scmid: default
+    spec:
+      matchpattern: >
+        unittest_version=(.*)
+      replacepattern: >
+        unittest_version={{ source "latestRelease" }}
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `helm-unittest` helm plugin version to {{ source "latestRelease" }}
+    spec:
+      labels:
+        - dependencies
+        - helm-unittest


### PR DESCRIPTION
This PR pins the helm plugin version used in the GitHub Action workflow to test several charts.

Follow-up of #512 

Set to before last version to check updatecli manifest.