### PR TITLE
fix(mirrorbits): use the PVC name defined in values.yaml everywhere

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.52.2
+version: 0.53.0

--- a/charts/mirrorbits/templates/deployment.files.yaml
+++ b/charts/mirrorbits/templates/deployment.files.yaml
@@ -60,6 +60,8 @@ spec:
         - name: conf
           configMap:
             name: {{ include "mirrorbits.fullname" . }}-files
+        {{ if .Values.repository.persistentVolumeClaim.enabled -}}
         - name: binary
           persistentVolumeClaim:
-            claimName: {{ include "mirrorbits.fullname" . }}-binary
+            claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
+        {{- end }}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -126,5 +126,5 @@ spec:
         {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
         - name: binary
           persistentVolumeClaim:
-            claimName: {{ include "mirrorbits.fullname" . }}-binary
+            claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
         {{- end -}}


### PR DESCRIPTION
As it is currently, even with a `repository.name` value specified in values.yaml, the PVC is named only in the PVC template, it has a generic release name + "-binary" in the deployments templates.

This PR fixes that.

Note: I don't see why there are `$.` in front of some of the `if` in these deployments an in the PVC template 🤔 