### PR TITLE
chore(mirrorbits): add unit testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - httpredirector
           - jenkins-jobs
           - jenkins-kubernetes-agents
+          - mirrorbits
           - plugin-health-scoring
       fail-fast: false
     steps:

--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.54.0
+version: 0.53.3

--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.53.1
+version: 0.54.0

--- a/charts/mirrorbits/tests/default_secrets_values.yaml
+++ b/charts/mirrorbits/tests/default_secrets_values.yaml
@@ -1,0 +1,3 @@
+geoipupdate:
+  account_id: my-account-id
+  license_key: my-license-key

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -1,0 +1,12 @@
+suite: default tests
+values:
+  - ../values.yaml
+  - default_secrets_values.yaml
+templates:
+  - ingress.yaml
+tests:
+  - it: should not create any ingress by default
+    template: ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
This PR adds unit testing to the mirrorbits chart in order to fix the issues I've encountered when working on https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1660258021 trying to deploy https://github.com/jenkins-infra/kubernetes-management/pull/4211.

The current chart does not pass this basic test as it needs to be fixed with https://github.com/jenkins-infra/helm-charts/pull/585/commits/b2967643d67e3cab10f24b1a76b4066b15838a62.

~Indeed, even if this code block is commented, the template engine tries to retrieve `.Values.resource.mirrorbits`, undefined in the default chart values.~
WTH... It passes here now with helm-unittest 🤔

Anyway, it still fails with helm:
```
$ helm template test ./charts/mirrorbits -f ./charts/mirrorbits/values.yaml -f ./charts/mirrorbits/tests/default_secrets_values.yaml --debug
[...]
Error: YAML parse error on mirrorbits/templates/deployment.yaml: error converting YAML to JSON: yaml: line 59: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 59: did not find expected key
YAML parse error on mirrorbits/templates/deployment.yaml
```

I'll do another PR to fix it.

Extracted from #585 