### PR TITLE
fix(check-chart-version-bump): use only one job to be able to set it as required

### DIFF
--- a/.github/workflows/check-chart-versions-bump.yml
+++ b/.github/workflows/check-chart-versions-bump.yml
@@ -17,50 +17,52 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Retrieve the list of modified chart names in the pull request
-          modifiedCharts=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' | xargs dirname | grep "^charts/" | cut -d "/" -f 2 | sort --unique)
+          modifiedCharts=$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path' | xargs dirname | grep "^charts/" | cut -d "/" -f 2 | sort --unique | tr '\n' ',')
 
-          jsonArray=""
-          if [ -n "$modifiedCharts" ]; then
-            echo "= List of modified charts:"
-            echo "$modifiedCharts"
-            # Convert to JSON array
-            jsonArray=$(echo "$modifiedCharts" | jq --raw-input --slurp 'split("\n") | map(select(length > 0))' | tr -d '\n')
-          else
+          # Remove last comma
+          modifiedCharts="${modifiedCharts%,}"
+
+          if [ -z "$modifiedCharts" ]; then
             echo "= Info: no modified chart found."
+          else
+            echo "= modified chart(s): ${modifiedCharts}"
           fi
 
-          # Store the JSON as step output
-          echo "modified_charts={\"chart\": ${jsonArray}}" >> "$GITHUB_OUTPUT"
-  check_chart_version_bump:
-    runs-on: ubuntu-latest
-    needs: find_modified_charts
-    if: ${{ needs.find_modified_charts.outputs.charts_matrix != '' }}  # Without it, the strategy parser will fail if the charts_matrix is empty.
-    name: Check chart version bump
-    strategy:
-      matrix: ${{fromJson(needs.find_modified_charts.outputs.charts_matrix)}}
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
+          # Store the result
+          echo "modified_charts=${modifiedCharts}" >> "$GITHUB_OUTPUT"
       - id: check_bump
+        if: steps.list_modified_charts.outputs.modified_charts != ''
         name: Check if chart version has been bumped
         run: |
           git fetch --quiet origin pull/${{ github.event.pull_request.number }}/head:pr-branch
           git fetch --quiet origin ${{ github.event.pull_request.base.ref }}:target-branch
-          
-          # Retrieve version from each branch Chart.yaml, or empty if it does not exist
-          MAIN_CHART_VERSION=$(git show target-branch:charts/${{ matrix.chart }}/Chart.yaml 2>/dev/null | grep "^version:" | cut -d " " -f 2)
-          PR_CHART_VERSION=$(git show pr-branch:charts/${{ matrix.chart }}/Chart.yaml 2>/dev/null | grep "^version:" | cut -d " " -f 2)
 
-          # If it's a new chart we're just informing the file doesn't exist or a version can't be read from it on the target branch
-          if [ -z "$MAIN_CHART_VERSION" ]; then
-            echo "= Info: charts/${{ matrix.chart }}/Chart.yaml doesn't exist or a version can't be read from it on the target branch."
-          fi
+          # Set IFS to a comma to split the string into an array
+          IFS=',' read -ra chartNames <<< "${{ steps.list_modified_charts_with_unit_tests.outputs.modified_charts_with_unit_tests }}"
 
-          # If the version hasn't been bumped between the pull request and the target branch
-          # or if there is no Chart.yaml in the pull request branch
-          if [ "$MAIN_CHART_VERSION" == "$PR_CHART_VERSION" ] || [ -z "$PR_CHART_VERSION" ]; then
-            echo "= ERROR: the version of the '${{ matrix.chart }}' chart hasn't been bumped: '$PR_CHART_VERSION'."
+          notBumped=0
+
+          for chartName in "${chartNames[@]}"; do          
+            # Retrieve version from each branch Chart.yaml, or empty if it does not exist
+            MAIN_CHART_VERSION=$(git show target-branch:charts/$chartName/Chart.yaml 2>/dev/null | grep "^version:" | cut -d " " -f 2)
+            PR_CHART_VERSION=$(git show pr-branch:charts/$chartName/Chart.yaml 2>/dev/null | grep "^version:" | cut -d " " -f 2)
+
+            # If it's a new chart we're just informing the file doesn't exist or a version can't be read from it on the target branch
+            if [ -z "$MAIN_CHART_VERSION" ]; then
+              echo "= Info: charts/$chartName/Chart.yaml doesn't exist or a version can't be read from it on the target branch."
+            fi
+
+            # If the version hasn't been bumped between the pull request and the target branch
+            # or if there is no Chart.yaml in the pull request branch
+            if [ "$MAIN_CHART_VERSION" == "$PR_CHART_VERSION" ] || [ -z "$PR_CHART_VERSION" ]; then
+              echo "= ERROR: the version of the '$chartName' chart hasn't been bumped: '$PR_CHART_VERSION'."
+              ((notBumped++))
+            fi
+
+            echo "= Info: the version of the '$chartName' chart has been bumped from '$MAIN_CHART_VERSION' to '$PR_CHART_VERSION'."
+          done
+
+          if [ "$notBumped" -gt 0 ]; then
+            echo "= ERROR: there is at least a version of a chart that hasn't been bumped."
             exit 1
           fi
-
-          echo "= Info: the version of the '${{ matrix.chart }}' chart has been bumped from '$MAIN_CHART_VERSION' to '$PR_CHART_VERSION'."


### PR DESCRIPTION
This PR uses only one job intead of a matrix with 2 separate jobs so this GHA check can be set as required in branch protection settings.

Ref: https://github.com/jenkins-infra/helm-charts/issues/596#issuecomment-1686243269
            