### PR TITLE
chore: restore `mirror` chart

### DIFF
--- a/charts/mirror/.helmignore
+++ b/charts/mirror/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mirror/Chart.yaml
+++ b/charts/mirror/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart which deploys a Jenkins mirror
+name: mirror
+version: 0.1.23

--- a/charts/mirror/README.md
+++ b/charts/mirror/README.md
@@ -1,0 +1,12 @@
+# Mirror
+
+This helm charts starts three containers:
+- One to synchronize remote Jenkins mirror with a local directory using rsync command from a cronjob
+- A second one that serves synchronized files using apache
+- A third one that serves files using a rsyncd daemon, this third containers is only designed to be used by get.jenkins.io
+
+# Running this yourself.
+
+! By default the helm chart is configured to provision a volume based on the default storage class. A different persistentVolume can be specified by modifying the variable `persistent`
+ 
+`helmfile -f helmfile.d/mirror.yaml apply`

--- a/charts/mirror/templates/NOTES.txt
+++ b/charts/mirror/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mirror.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mirror.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mirror.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mirror.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/mirror/templates/_helpers.tpl
+++ b/charts/mirror/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mirror.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mirror.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mirror.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mirror.labels" -}}
+app.kubernetes.io/name: {{ include "mirror.name" . }}
+helm.sh/chart: {{ include "mirror.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/mirror/templates/configmap.yaml
+++ b/charts/mirror/templates/configmap.yaml
@@ -1,0 +1,529 @@
+# Disable  configmap for now
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mirror.fullname" . }}
+data:
+  httpd.conf: |
+    ServerRoot "/usr/local/apache2"
+    
+    Listen 80
+    
+    #
+    # Dynamic Shared Object (DSO) Support
+    #
+    # To be able to use the functionality of a module which was built as a DSO you
+    # have to place corresponding `LoadModule' lines at this location so the
+    # directives contained in it are actually available _before_ they are used.
+    # Statically compiled modules (those listed by `httpd -l') do not need
+    # to be loaded here.
+    #
+    # Example:
+    # LoadModule foo_module modules/mod_foo.so
+    #
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    #LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+    #LoadModule mpm_worker_module modules/mod_mpm_worker.so
+    LoadModule authn_file_module modules/mod_authn_file.so
+    #LoadModule authn_dbm_module modules/mod_authn_dbm.so
+    #LoadModule authn_anon_module modules/mod_authn_anon.so
+    #LoadModule authn_dbd_module modules/mod_authn_dbd.so
+    #LoadModule authn_socache_module modules/mod_authn_socache.so
+    LoadModule authn_core_module modules/mod_authn_core.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    #LoadModule authz_dbm_module modules/mod_authz_dbm.so
+    #LoadModule authz_owner_module modules/mod_authz_owner.so
+    #LoadModule authz_dbd_module modules/mod_authz_dbd.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    #LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+    #LoadModule authnz_fcgi_module modules/mod_authnz_fcgi.so
+    LoadModule access_compat_module modules/mod_access_compat.so
+    LoadModule auth_basic_module modules/mod_auth_basic.so
+    #LoadModule auth_form_module modules/mod_auth_form.so
+    #LoadModule auth_digest_module modules/mod_auth_digest.so
+    #LoadModule allowmethods_module modules/mod_allowmethods.so
+    #LoadModule isapi_module modules/mod_isapi.so
+    #LoadModule file_cache_module modules/mod_file_cache.so
+    #LoadModule cache_module modules/mod_cache.so
+    #LoadModule cache_disk_module modules/mod_cache_disk.so
+    #LoadModule cache_socache_module modules/mod_cache_socache.so
+    #LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+    #LoadModule socache_dbm_module modules/mod_socache_dbm.so
+    #LoadModule socache_memcache_module modules/mod_socache_memcache.so
+    #LoadModule socache_redis_module modules/mod_socache_redis.so
+    #LoadModule watchdog_module modules/mod_watchdog.so
+    #LoadModule macro_module modules/mod_macro.so
+    #LoadModule dbd_module modules/mod_dbd.so
+    #LoadModule bucketeer_module modules/mod_bucketeer.so
+    #LoadModule dumpio_module modules/mod_dumpio.so
+    #LoadModule echo_module modules/mod_echo.so
+    #LoadModule example_hooks_module modules/mod_example_hooks.so
+    #LoadModule case_filter_module modules/mod_case_filter.so
+    #LoadModule case_filter_in_module modules/mod_case_filter_in.so
+    #LoadModule example_ipc_module modules/mod_example_ipc.so
+    #LoadModule buffer_module modules/mod_buffer.so
+    #LoadModule data_module modules/mod_data.so
+    #LoadModule ratelimit_module modules/mod_ratelimit.so
+    LoadModule reqtimeout_module modules/mod_reqtimeout.so
+    #LoadModule ext_filter_module modules/mod_ext_filter.so
+    #LoadModule request_module modules/mod_request.so
+    #LoadModule include_module modules/mod_include.so
+    LoadModule filter_module modules/mod_filter.so
+    #LoadModule reflector_module modules/mod_reflector.so
+    #LoadModule substitute_module modules/mod_substitute.so
+    #LoadModule sed_module modules/mod_sed.so
+    #LoadModule charset_lite_module modules/mod_charset_lite.so
+    #LoadModule deflate_module modules/mod_deflate.so
+    #LoadModule xml2enc_module modules/mod_xml2enc.so
+    #LoadModule proxy_html_module modules/mod_proxy_html.so
+    #LoadModule brotli_module modules/mod_brotli.so
+    LoadModule mime_module modules/mod_mime.so
+    #LoadModule ldap_module modules/mod_ldap.so
+    LoadModule log_config_module modules/mod_log_config.so
+    #LoadModule log_debug_module modules/mod_log_debug.so
+    #LoadModule log_forensic_module modules/mod_log_forensic.so
+    #LoadModule logio_module modules/mod_logio.so
+    #LoadModule lua_module modules/mod_lua.so
+    LoadModule env_module modules/mod_env.so
+    #LoadModule mime_magic_module modules/mod_mime_magic.so
+    #LoadModule cern_meta_module modules/mod_cern_meta.so
+    #LoadModule expires_module modules/mod_expires.so
+    LoadModule headers_module modules/mod_headers.so
+    #LoadModule ident_module modules/mod_ident.so
+    #LoadModule usertrack_module modules/mod_usertrack.so
+    #LoadModule unique_id_module modules/mod_unique_id.so
+    LoadModule setenvif_module modules/mod_setenvif.so
+    LoadModule version_module modules/mod_version.so
+    #LoadModule remoteip_module modules/mod_remoteip.so
+    #LoadModule proxy_module modules/mod_proxy.so
+    #LoadModule proxy_connect_module modules/mod_proxy_connect.so
+    #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+    #LoadModule proxy_http_module modules/mod_proxy_http.so
+    #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+    #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
+    #LoadModule proxy_uwsgi_module modules/mod_proxy_uwsgi.so
+    #LoadModule proxy_fdpass_module modules/mod_proxy_fdpass.so
+    #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+    #LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+    #LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+    #LoadModule proxy_express_module modules/mod_proxy_express.so
+    #LoadModule proxy_hcheck_module modules/mod_proxy_hcheck.so
+    #LoadModule session_module modules/mod_session.so
+    #LoadModule session_cookie_module modules/mod_session_cookie.so
+    #LoadModule session_crypto_module modules/mod_session_crypto.so
+    #LoadModule session_dbd_module modules/mod_session_dbd.so
+    #LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+    #LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+    #LoadModule ssl_module modules/mod_ssl.so
+    #LoadModule optional_hook_export_module modules/mod_optional_hook_export.so
+    #LoadModule optional_hook_import_module modules/mod_optional_hook_import.so
+    #LoadModule optional_fn_import_module modules/mod_optional_fn_import.so
+    #LoadModule optional_fn_export_module modules/mod_optional_fn_export.so
+    #LoadModule dialup_module modules/mod_dialup.so
+    #LoadModule http2_module modules/mod_http2.so
+    #LoadModule proxy_http2_module modules/mod_proxy_http2.so
+    #LoadModule md_module modules/mod_md.so
+    #LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
+    #LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so
+    #LoadModule lbmethod_bybusyness_module modules/mod_lbmethod_bybusyness.so
+    #LoadModule lbmethod_heartbeat_module modules/mod_lbmethod_heartbeat.so
+    LoadModule unixd_module modules/mod_unixd.so
+    #LoadModule heartbeat_module modules/mod_heartbeat.so
+    #LoadModule heartmonitor_module modules/mod_heartmonitor.so
+    #LoadModule dav_module modules/mod_dav.so
+    LoadModule status_module modules/mod_status.so
+    LoadModule autoindex_module modules/mod_autoindex.so
+    #LoadModule asis_module modules/mod_asis.so
+    #LoadModule info_module modules/mod_info.so
+    #LoadModule suexec_module modules/mod_suexec.so
+    <IfModule !mpm_prefork_module>
+    	#LoadModule cgid_module modules/mod_cgid.so
+    </IfModule>
+    <IfModule mpm_prefork_module>
+    	#LoadModule cgi_module modules/mod_cgi.so
+    </IfModule>
+    #LoadModule dav_fs_module modules/mod_dav_fs.so
+    #LoadModule dav_lock_module modules/mod_dav_lock.so
+    #LoadModule vhost_alias_module modules/mod_vhost_alias.so
+    #LoadModule negotiation_module modules/mod_negotiation.so
+    LoadModule dir_module modules/mod_dir.so
+    #LoadModule imagemap_module modules/mod_imagemap.so
+    #LoadModule actions_module modules/mod_actions.so
+    #LoadModule speling_module modules/mod_speling.so
+    #LoadModule userdir_module modules/mod_userdir.so
+    LoadModule alias_module modules/mod_alias.so
+    #LoadModule rewrite_module modules/mod_rewrite.so
+    
+    <IfModule unixd_module>
+    #
+    # If you wish httpd to run as a different user or group, you must run
+    # httpd as root initially and it will switch.
+    #
+    # User/Group: The name (or #number) of the user/group to run httpd as.
+    # It is usually good practice to create a dedicated user and group for
+    # running httpd, as with most system services.
+    #
+    User daemon
+    Group daemon
+    
+    </IfModule>
+    
+    # 'Main' server configuration
+    #
+    # The directives in this section set up the values used by the 'main'
+    # server, which responds to any requests that aren't handled by a
+    # <VirtualHost> definition.  These values also provide defaults for
+    # any <VirtualHost> containers you may define later in the file.
+    #
+    # All of these directives may appear inside <VirtualHost> containers,
+    # in which case these default settings will be overridden for the
+    # virtual host being defined.
+    #
+    
+    #
+    # ServerAdmin: Your address, where problems with the server should be
+    # e-mailed.  This address appears on some server-generated pages, such
+    # as error documents.  e.g. admin@your-domain.com
+    #
+    ServerAdmin me@olblak.com
+    
+    #
+    # ServerName gives the name and port that the server uses to identify itself.
+    # This can often be determined automatically, but we recommend you specify
+    # it explicitly to prevent problems during startup.
+    #
+    # If your host doesn't have a registered DNS name, enter its IP address here.
+    #
+    #ServerName www.example.com:80
+    
+    #
+    # Deny access to the entirety of your server's filesystem. You must
+    # explicitly permit access to web content directories in other
+    # <Directory> blocks below.
+    #
+    <Directory />
+        AllowOverride none
+        Require all denied
+    </Directory>
+    
+    #
+    # Note that from this point forward you must specifically allow
+    # particular features to be enabled - so if something's not working as
+    # you might expect, make sure that you have specifically enabled it
+    # below.
+    #
+    
+    #
+    # DocumentRoot: The directory out of which you will serve your
+    # documents. By default, all requests are taken from this directory, but
+    # symbolic links and aliases may be used to point to other locations.
+    #
+    DocumentRoot "/usr/local/apache2/htdocs"
+    <Directory "/usr/local/apache2/htdocs">
+        #
+        # Possible values for the Options directive are "None", "All",
+        # or any combination of:
+        #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+        #
+        # Note that "MultiViews" must be named *explicitly* --- "Options All"
+        # doesn't give it to you.
+        #
+        # The Options directive is both complicated and important.  Please see
+        # http://httpd.apache.org/docs/2.4/mod/core.html#options
+        # for more information.
+        #
+        Options Indexes FollowSymLinks
+    
+        #
+        # AllowOverride controls what directives may be placed in .htaccess files.
+        # It can be "All", "None", or any combination of the keywords:
+        #   AllowOverride FileInfo AuthConfig Limit
+        #
+        AllowOverride FileInfo
+    
+        #
+        # Controls who can get stuff from this server.
+        #
+        Require all granted
+
+        IndexOptions FancyIndexing VersionSort TrackModified FoldersFirst SuppressHTMLPreamble NameWidth=* SuppressRules SuppressIcon SuppressDescription
+
+        HeaderName HEADER.html
+        ReadmeName FOOTER.html
+
+        IndexIgnore HEADER* FOOTER* index.html
+    </Directory>
+    
+    #
+    # DirectoryIndex: sets the file that Apache will serve if a directory
+    # is requested.
+    #
+    <IfModule dir_module>
+        DirectoryIndex index.html
+    </IfModule>
+    
+    #
+    # The following lines prevent .htaccess and .htpasswd files from being
+    # viewed by Web clients.
+    #
+    <Files ".ht*">
+        Require all denied
+    </Files>
+    
+    #
+    # ErrorLog: The location of the error log file.
+    # If you do not specify an ErrorLog directive within a <VirtualHost>
+    # container, error messages relating to that virtual host will be
+    # logged here.  If you *do* define an error logfile for a <VirtualHost>
+    # container, that host's errors will be logged there and not here.
+    #
+    ErrorLog /proc/self/fd/2
+    
+    #
+    # LogLevel: Control the number of messages logged to the error_log.
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    #
+    LogLevel warn
+    
+    <IfModule log_config_module>
+        #
+        # The following directives define some format nicknames for use with
+        # a CustomLog directive (see below).
+        #
+        LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+        LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    
+        <IfModule logio_module>
+          # You need to enable mod_logio.c to use %I and %O
+          LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+        </IfModule>
+    
+        #
+        # The location and format of the access logfile (Common Logfile Format).
+        # If you do not define any access logfiles within a <VirtualHost>
+        # container, they will be logged here.  Contrariwise, if you *do*
+        # define per-<VirtualHost> access logfiles, transactions will be
+        # logged therein and *not* in this file.
+        #
+        CustomLog /proc/self/fd/1 common
+    
+        #
+        # If you prefer a logfile with access, agent, and referer information
+        # (Combined Logfile Format) you can use the following directive.
+        #
+        #CustomLog "logs/access_log" combined
+    </IfModule>
+    
+    <IfModule alias_module>
+        #
+        # Redirect: Allows you to tell clients about documents that used to
+        # exist in your server's namespace, but do not anymore. The client
+        # will make a new request for the document at its new location.
+        # Example:
+        # Redirect permanent /foo http://www.example.com/bar
+    
+        #
+        # Alias: Maps web paths into filesystem paths and is used to
+        # access content that does not live under the DocumentRoot.
+        # Example:
+        # Alias /webpath /full/filesystem/path
+        #
+        # If you include a trailing / on /webpath then the server will
+        # require it to be present in the URL.  You will also likely
+        # need to provide a <Directory> section to allow access to
+        # the filesystem path.
+    
+        #
+        # ScriptAlias: This controls which directories contain server scripts.
+        # ScriptAliases are essentially the same as Aliases, except that
+        # documents in the target directory are treated as applications and
+        # run by the server when requested rather than as documents sent to the
+        # client.  The same rules about trailing "/" apply to ScriptAlias
+        # directives as to Alias.
+        #
+        ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+    
+    </IfModule>
+    
+    <IfModule cgid_module>
+        #
+        # ScriptSock: On threaded servers, designate the path to the UNIX
+        # socket used to communicate with the CGI daemon of mod_cgid.
+        #
+        #Scriptsock cgisock
+    </IfModule>
+    
+    #
+    # "/usr/local/apache2/cgi-bin" should be changed to whatever your ScriptAliased
+    # CGI directory exists, if you have that configured.
+    #
+    <Directory "/usr/local/apache2/cgi-bin">
+        AllowOverride None
+        Options None
+        Require all granted
+    </Directory>
+    
+    <IfModule headers_module>
+        #
+        # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
+        # backend servers which have lingering "httpoxy" defects.
+        # 'Proxy' request header is undefined by the IETF, not listed by IANA
+        #
+        RequestHeader unset Proxy early
+    </IfModule>
+    
+    <IfModule mime_module>
+        #
+        # TypesConfig points to the file containing the list of mappings from
+        # filename extension to MIME-type.
+        #
+        TypesConfig conf/mime.types
+    
+        #
+        # AddType allows you to add to or override the MIME configuration
+        # file specified in TypesConfig for specific file types.
+        #
+        #AddType application/x-gzip .tgz
+        #
+        # AddEncoding allows you to have certain browsers uncompress
+        # information on the fly. Note: Not all browsers support this.
+        #
+        #AddEncoding x-compress .Z
+        #AddEncoding x-gzip .gz .tgz
+        #
+        # If the AddEncoding directives above are commented-out, then you
+        # probably should define those extensions to indicate media types:
+        #
+        AddType application/x-compress .Z
+        AddType application/x-gzip .gz .tgz
+    
+        #
+        # AddHandler allows you to map certain file extensions to "handlers":
+        # actions unrelated to filetype. These can be either built into the server
+        # or added with the Action directive (see below)
+        #
+        # To use CGI scripts outside of ScriptAliased directories:
+        # (You will also need to add "ExecCGI" to the "Options" directive.)
+        #
+        #AddHandler cgi-script .cgi
+    
+        # For type maps (negotiated resources):
+        #AddHandler type-map var
+    
+        #
+        # Filters allow you to process content before it is sent to the client.
+        #
+        # To parse .shtml files for server-side includes (SSI):
+        # (You will also need to add "Includes" to the "Options" directive.)
+        #
+        #AddType text/html .shtml
+        #AddOutputFilter INCLUDES .shtml
+    </IfModule>
+    
+    #
+    # The mod_mime_magic module allows the server to use various hints from the
+    # contents of the file itself to determine its type.  The MIMEMagicFile
+    # directive tells the module where the hint definitions are located.
+    #
+    #MIMEMagicFile conf/magic
+    
+    #
+    # Customizable error responses come in three flavors:
+    # 1) plain text 2) local redirects 3) external redirects
+    #
+    # Some examples:
+    #ErrorDocument 500 "The server made a boo boo."
+    #ErrorDocument 404 /missing.html
+    #ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+    #ErrorDocument 402 http://www.example.com/subscription_info.html
+    #
+    
+    #
+    # MaxRanges: Maximum number of Ranges in a request before
+    # returning the entire resource, or one of the special
+    # values 'default', 'none' or 'unlimited'.
+    # Default setting is to accept 200 Ranges.
+    #MaxRanges unlimited
+    
+    #
+    # EnableMMAP and EnableSendfile: On systems that support it,
+    # memory-mapping or the sendfile syscall may be used to deliver
+    # files.  This usually improves server performance, but must
+    # be turned off when serving from networked-mounted
+    # filesystems or if support for these functions is otherwise
+    # broken on your system.
+    # Defaults: EnableMMAP On, EnableSendfile Off
+    #
+    EnableMMAP off
+    #EnableSendfile on
+    
+    # Supplemental configuration
+    #
+    # The configuration files in the conf/extra/ directory can be
+    # included to add extra features or to modify the default configuration of
+    # the server, or you may simply copy their contents here and change as
+    # necessary.
+    
+    # Server-pool management (MPM specific)
+    #Include conf/extra/httpd-mpm.conf
+    
+    # Multi-language error messages
+    #Include conf/extra/httpd-multilang-errordoc.conf
+    
+    # Fancy directory listings
+    #Include conf/extra/httpd-autoindex.conf
+    
+    # Language settings
+    #Include conf/extra/httpd-languages.conf
+    
+    # User home directories
+    #Include conf/extra/httpd-userdir.conf
+    
+    # Real-time info on requests and configuration
+    #Include conf/extra/httpd-info.conf
+    
+    # Virtual hosts
+    #Include conf/extra/httpd-vhosts.conf
+    
+    # Local access to the Apache HTTP Server Manual
+    #Include conf/extra/httpd-manual.conf
+    
+    # Distributed authoring and versioning (WebDAV)
+    #Include conf/extra/httpd-dav.conf
+    
+    # Various default settings
+    #Include conf/extra/httpd-default.conf
+    
+    # Configure mod_proxy_html to understand HTML4/XHTML1
+    <IfModule proxy_html_module>
+    Include conf/extra/proxy-html.conf
+    </IfModule>
+    
+    # Secure (SSL/TLS) connections
+    #Include conf/extra/httpd-ssl.conf
+    #
+    # Note: The following must must be present to support
+    #       starting without SSL on platforms with no /dev/random equivalent
+    #       but a statically compiled-in mod_ssl.
+    #
+    <IfModule ssl_module>
+    SSLRandomSeed startup builtin
+    SSLRandomSeed connect builtin
+    </IfModule>
+
+
+{{- if .Values.synchronize.enabled }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mirror.fullname" . }}-cronjobs
+data:
+  root: |
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    {{ .Values.synchronize.period }} rsync -avz {{ .Values.synchronize.upstream }} /packages
+{{ end }}

--- a/charts/mirror/templates/deployment.yaml
+++ b/charts/mirror/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mirror.fullname" . }}
+  labels:
+{{ include "mirror.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy: 
+    {{- toYaml .Values.strategy | nindent 4 }} 
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "mirror.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "mirror.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: web
+          image: "{{ .Values.images.web.repository }}:{{ .Values.images.web.tag }}"
+          imagePullPolicy: {{ .Values.images.web.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+             port: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources.web | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistent.volumeClaim.enabled }}
+            - name: binary
+              mountPath: /usr/local/apache2/htdocs
+              readOnly: true
+          {{- end }}
+            - name: conf
+              mountPath: /usr/local/apache2/conf/httpd.conf
+              subPath: httpd.conf
+              readOnly: true
+      {{- if .Values.synchronize.enabled }}
+        - name: cron
+          image: "{{ .Values.images.cron.repository }}:{{ .Values.images.cron.tag }}"
+          imagePullPolicy: {{ .Values.images.cron.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources.cron | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistent.volumeClaim.enabled }}
+            - name: binary
+              mountPath: /packages
+          {{- end }}
+            - name: cronjobs
+              mountPath: /etc/crontabs/
+              readOnly: true
+        - name: rsyncd
+          image: "{{ .Values.images.rsyncd.repository }}:{{ .Values.images.rsyncd.tag }}"
+          imagePullPolicy: {{ .Values.images.rsyncd.pullPolicy }}
+          ports:
+            - name: rsyncd
+              containerPort: 873
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+             port: 873
+          readinessProbe:
+            tcpSocket:
+             port: 873
+          resources:
+            {{- toYaml .Values.resources.rsyncd | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistent.volumeClaim.enabled }}
+            - name: binary
+              mountPath: /srv/releases/jenkins
+              readOnly: true
+          {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+        - name: conf
+          configMap:
+            name: {{ include "mirror.fullname" . }}
+            items:
+              - key: httpd.conf
+                path: httpd.conf
+        {{- if .Values.persistent.volumeClaim.enabled }}
+        - name: binary
+          persistentVolumeClaim:
+            claimName:  {{ $.Values.persistent.volumeClaim.name | default (printf "%s-binary" (include "mirror.fullname" .))  }}
+        {{- end }}
+      {{- if .Values.synchronize.enabled }}
+        - name: cronjobs
+          configMap:
+            name: {{ include "mirror.fullname" . }}-cronjobs
+      {{- end }}

--- a/charts/mirror/templates/ingress.yaml
+++ b/charts/mirror/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mirror.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "mirror.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ int ($.Values.service.web.port) }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mirror/templates/persistentVolume.yaml
+++ b/charts/mirror/templates/persistentVolume.yaml
@@ -1,0 +1,11 @@
+{{ if $.Values.persistent.volume.enabled -}}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $.Values.persistent.volume.name | default (printf "%s-binary" (include "mirror.fullname" .))}}
+  labels:
+    data: {{ $.Values.persistent.volume.name | default (printf "%s-binary" (include "mirror.fullname" .))}}
+spec:
+{{ toYaml $.Values.persistent.volume.spec | nindent 2 }}
+{{- end -}}

--- a/charts/mirror/templates/persistentVolumeClaim.yaml
+++ b/charts/mirror/templates/persistentVolumeClaim.yaml
@@ -1,0 +1,9 @@
+{{ if $.Values.persistent.volumeClaim.enabled -}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $.Values.persistent.volumeClaim.name | default (printf "%s-binary" (include "mirror.fullname" .))  }}
+spec:
+{{ toYaml $.Values.persistent.volumeClaim.spec | nindent 2 }}
+{{- end -}}

--- a/charts/mirror/templates/secret.yaml
+++ b/charts/mirror/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{ if $.Values.persistent.secret.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $.Values.persistent.volumeClaim.name | default (printf "%s-binary" (include "mirror.fullname" .))  }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.persistent.secret.data }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end -}}

--- a/charts/mirror/templates/service-rsyncd.yaml
+++ b/charts/mirror/templates/service-rsyncd.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mirror.fullname" . }}-rsyncd
+  labels:
+{{ include "mirror.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.rsyncd.type }}
+  {{- if eq .Values.service.rsyncd.type "LoadBalancer" }}
+  {{- if .Values.service.rsyncd.IP }}
+  loadBalancerIP: {{ .Values.service.rsyncd.IP }}
+  {{- end }}
+  loadBalancerSourceRanges:
+    {{- range .Values.service.rsyncd.whitelisted_sources }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+
+  ports:
+    - port: {{ .Values.service.rsyncd.port }}
+      targetPort: 873
+      protocol: TCP
+      name: rsyncd
+  selector:
+    app.kubernetes.io/name: {{ include "mirror.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mirror/templates/service-web.yaml
+++ b/charts/mirror/templates/service-web.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mirror.fullname" . }}
+  labels:
+{{ include "mirror.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.web.type }}
+  {{- if eq .Values.service.web.type "LoadBalancer" }}
+  {{- if .Values.service.web.IP }}
+  loadBalancerIP: {{ .Values.service.IP }}
+  {{- end }}
+  loadBalancerSourceRanges:
+    {{- range .Values.service.web.whitelisted_sources }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+
+  ports:
+    - port: {{ .Values.service.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "mirror.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mirror/templates/tests/test-connection.yaml
+++ b/charts/mirror/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mirror.fullname" . }}-test-connection"
+  labels:
+{{ include "mirror.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "mirror.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/mirror/values.yaml
+++ b/charts/mirror/values.yaml
@@ -1,0 +1,103 @@
+# Default values for mirror.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+strategy:
+  #rollingUpdate:
+  #  maxSurge: 25%
+  #  maxUnavailable: 25%
+  #type: RollingUpdate
+  # By default we use an azure disk which do not support multi mount so
+  # we must be sure that all containers are stopped before deploying the new one
+  type: Recreate
+images:
+  web:
+    repository: httpd
+    tag: 2.4
+    pullPolicy: Always
+  cron:
+    repository: olblak/crond
+    tag: latest
+    pullPolicy: Always
+  rsyncd:
+    repository: jenkinsciinfra/rsyncd@sha256
+    tag: bc5b180219c491e514234ad1c7274f53cf8161c4be90be86dae9231f843e8417
+    pullPolicy: Always
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+service:
+  web:
+    type: ClusterIP
+    port: 80
+    #    IP:
+    #    whitelisted_sources:
+    #      - 
+  rsyncd:
+    type: ClusterIP
+    port: 873
+    #    IP:
+    whitelisted_sources:
+      - 52.167.253.43/32
+      - 52.202.51.185/32
+# ingress:
+#  enabled: true
+#  annotations: 
+#    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+#    "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
+#
+#  hosts:
+#    - host: mirror.jenkins.io
+#  tls:
+#    - secretName: releasemirror-tls
+#      hosts:
+#        - mirror.jenkins.io
+resources:
+  web:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  cron:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  rsyncd:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+nodeSelector: {}
+tolerations: []
+affinity: {}
+persistent:
+  volume:
+    name: mirror-binary
+    enabled: false
+    spec: {}
+  volumeClaim:
+    name: mirror-binary
+    enabled: false
+    spec:
+      storageClassName: default
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 200Gi
+  secret:
+    name: mirror-binary
+    enabled: false
+    data: {}
+synchronize:
+  enabled: false
+  upstream: "rsync://ftp-osl.osuosl.org/jenkins/"
+  period: "*/5 * * * *"


### PR DESCRIPTION
Restore the `mirror` chart removed in https://github.com/jenkins-infra/kubernetes-management/pull/1604 to use it for a rsync server dedicated to Update Center mirrorbits.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649