### PR TITLE
chore(updatecli) remove unused or deprecated manifest content for 0.57.0

### DIFF
--- a/updatecli/updatecli.d/accountapp.yaml
+++ b/updatecli/updatecli.d/accountapp.yaml
@@ -37,7 +37,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/accountapp
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/helm-unittest.yaml
+++ b/updatecli/updatecli.d/helm-unittest.yaml
@@ -29,7 +29,7 @@ targets:
     scmid: default
     spec:
       file: .github/workflows/test.yml
-      key: env.UNITTEST_VERSION
+      key: $.env.UNITTEST_VERSION
 
 actions:
   default:

--- a/updatecli/updatecli.d/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/incrementals-publisher.yaml
@@ -37,7 +37,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/incrementals-publisher
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/ircbot.yaml
+++ b/updatecli/updatecli.d/ircbot.yaml
@@ -38,7 +38,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/ircbot
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/ldap.yaml
+++ b/updatecli/updatecli.d/ldap.yaml
@@ -20,8 +20,9 @@ sources:
       image: "jenkinsciinfra/ldap"
       tag: "cron-latest"
       architecture: "amd64"
+      hidetag: true
     transformers:
-      - trimprefix: 'sha256:'
+      - trimprefix: '@sha256:'
   slapd:
     kind: dockerdigest
     name: Get jenkinsciinfra/ldap:latest docker image digest
@@ -29,8 +30,9 @@ sources:
       image: "jenkinsciinfra/ldap"
       tag: "latest"
       architecture: "amd64"
+      hidetag: true
     transformers:
-      - trimprefix: 'sha256:'
+      - trimprefix: '@sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 
@@ -41,7 +43,7 @@ targets:
     sourceid: crond
     spec:
       name: charts/ldap
-      key: image.crond.tag
+      key: $.image.crond.tag
       versionincrement: patch
     scmid: default
   updateChartSlapd:
@@ -50,7 +52,7 @@ targets:
     sourceid: slapd
     spec:
       name: charts/ldap
-      key: image.slapd.tag
+      key: $.image.slapd.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -28,8 +28,9 @@ sources:
       image: "httpd"
       tag: "2.4"
       architecture: "amd64"
+      hidetag: true
     transformers:
-      - trimprefix: 'sha256:'
+      - trimprefix: '@sha256:'
   latestGeoIPRelease:
     name: Get latest version of GeoIP
     kind: githubrelease
@@ -66,7 +67,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/mirrorbits
-      key: "image.mirrorbits.tag"
+      key: $.image.mirrorbits.tag
       versionincrement: patch
     scmid: default
   updateHttpd:
@@ -75,7 +76,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/mirrorbits
-      key: "image.files.tag"
+      key: $.image.files.tag
     scmid: default
   updateGeoIP:
     name: "Update maxmindinc/geoipupdate docker image version"
@@ -83,7 +84,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/mirrorbits
-      key: "geoipupdate.image.tag"
+      key: $.geoipupdate.image.tag
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -47,7 +47,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/javadoc
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
   updateJenkinsioChartEn:
@@ -55,7 +55,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/jenkinsio
-      key: images.en.tag
+      key: $.images.en.tag
       versionincrement: patch
     scmid: default
   updateJenkinsioChartZh:
@@ -63,7 +63,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/jenkinsio
-      key: images.zh.tag
+      key: $.images.zh.tag
       versionincrement: patch
     scmid: default
   updatePluginSiteChart:
@@ -71,7 +71,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/plugin-site
-      key: frontend.image.tag
+      key: $.frontend.image.tag
       versionincrement: patch
     scmid: default
   updateReportsChart:
@@ -79,7 +79,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/reports
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
   updateArtifactCachingProxy:
@@ -87,7 +87,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/artifact-caching-proxy
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -37,7 +37,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/plugin-health-scoring
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/plugin-site-issues.yaml
@@ -38,7 +38,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/plugin-site-issues
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/rating.yaml
+++ b/updatecli/updatecli.d/rating.yaml
@@ -38,7 +38,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/rating
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/rss2twitter.yaml
+++ b/updatecli/updatecli.d/rss2twitter.yaml
@@ -37,7 +37,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/rss2twitter
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -20,8 +20,9 @@ sources:
       image: "jenkinsciinfra/uplink"
       tag: "latest"
       architecture: "amd64"
+      hidetag: true
     transformers:
-      - trimprefix: 'sha256:'
+      - trimprefix: '@sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 
@@ -31,7 +32,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/uplink
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 

--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -37,7 +37,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/wiki
-      key: image.tag
+      key: $.image.tag
       versionincrement: patch
     scmid: default
 


### PR DESCRIPTION
This PR fixes the following updatecli issues in this repository:

- https://github.com/updatecli/updatecli/releases/tag/v0.57.0 introduces a breaking change in the docker digest sources
- We have a lot of warning about the YAMl resource keys
- Removed the rsyncd manifest as the charts was renamed (feel free to reintroduce a new one once #609 is merged)


Closes #603 #604 #605 