### PR TITLE
fixup(check-chart-versions-bump): better naming

### DIFF
--- a/.github/workflows/check-chart-versions-bump.yml
+++ b/.github/workflows/check-chart-versions-bump.yml
@@ -4,11 +4,9 @@ on:
     paths:
       - 'charts/**'
 jobs:
-  find_modified_charts:
+  check_version_bump_on_modified_charts:
     runs-on: ubuntu-latest
-    outputs:
-      charts_matrix: ${{ steps.list_modified_charts.outputs.modified_charts }}
-    name: Find modified charts
+    name: Check version bump on modified charts
     steps:
       - uses: actions/checkout@v3
       - id: list_modified_charts


### PR DESCRIPTION
And removed unused job output.

Fixup of #594 