### PR TITLE
fix(mirrorbits): unique names for rsyncd `deployment` and `ingress` resources

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.58.0
+version: 0.58.1

--- a/charts/mirrorbits/templates/deployment.rsyncd.yaml
+++ b/charts/mirrorbits/templates/deployment.rsyncd.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mirrorbits.fullname" . }}
+  name: {{ include "mirrorbits.fullname" . }}-rsyncd
   labels:
 {{ include "mirrorbits.labels" . | indent 4 }}
 spec:

--- a/charts/mirrorbits/templates/ingress.rsyncd.yaml
+++ b/charts/mirrorbits/templates/ingress.rsyncd.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-rsyncd
   labels:
 {{ include "mirrorbits.labels" . | indent 4 }}
   {{- with .Values.rsyncd.ingress.annotations }}


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/kubernetes-management/pull/4278#issuecomment-1690112769