### PR TITLE
feat(mirrorbits): allow setting rsyncd config files content

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.58.1
+version: 0.59.0

--- a/charts/mirrorbits/templates/configmap.rsyncd.jenkins-motd.yaml
+++ b/charts/mirrorbits/templates/configmap.rsyncd.jenkins-motd.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rsyncd.configurationFiles.jenkinsMotd.override }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mirrorbits.fullname" . }}-jenkins-motd
+data:
+  jenkins.motd:
+{{ .Values.rsyncd.configurationFiles.jenkinsMotd.content | indent 4 }}
+{{- end -}}

--- a/charts/mirrorbits/templates/configmap.rsyncd.rsyncd-conf.yaml
+++ b/charts/mirrorbits/templates/configmap.rsyncd.rsyncd-conf.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.rsyncd.configurationFiles.rsyncdConf.override }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mirrorbits.fullname" . }}-rsyncd-conf
+data:
+  rsyncd.conf:
+{{ .Values.rsyncd.configurationFiles.rsyncdConf.content | indent 4 }}
+{{- end -}}

--- a/charts/mirrorbits/templates/deployment.rsyncd.yaml
+++ b/charts/mirrorbits/templates/deployment.rsyncd.yaml
@@ -44,7 +44,18 @@ spec:
             - name: binary
               mountPath: /srv/repo
               readOnly: true
-
+            {{- if .Values.rsyncd.configurationFiles.rsyncdConf.override }}
+            - name: rsyncd-conf
+              mountPath: /etc/rsyncd.conf
+              subPath: rsyncd.conf
+              readOnly: true
+            {{- end }}
+            {{- if .Values.rsyncd.configurationFiles.jenkinsMotd.override }}
+            - name: jenkins-motd
+              mountPath: /etc/jenkins-motd
+              subPath: jenkins-motd
+              readOnly: true
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -61,4 +72,14 @@ spec:
         - name: binary
           persistentVolumeClaim:
             claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
+        {{- if .Values.rsyncd.configurationFiles.rsyncdConf.override }}
+        - name: rsyncd-conf
+          configMap:
+            name: {{ include "mirrorbits.fullname" . }}-rsyncd-conf
+        {{- end }}
+        {{- if .Values.rsyncd.configurationFiles.rsyncdConf.override }}
+        - name: jenkins-motd
+          configMap:
+            name: {{ include "mirrorbits.fullname" . }}-jenkins-motd
+        {{- end }}
 {{- end }}

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -129,3 +129,51 @@ rsyncd:
     requests:
       cpu: 50m
       memory: 64Mi
+  # Custom configuration files used to override default rsyncd settings defined in https://github.com/jenkins-infra/docker-rsyncd/tree/main/config
+  configurationFiles:
+    rsyncdConf:
+      override: false
+      # content: |-
+      #    # /etc/rsyncd: configuration file for
+      #    rsync daemon mode
+      #
+      #    # See rsyncd.conf man page for more options.
+      #
+      #    # configuration example:
+      #
+      #    uid = nobody
+      #    gid = nogroup
+      #    use chroot = yes
+      #    max connections = 0
+      #    pid file = /var/run/rsyncd.pid
+      #    exclude = lost+found/
+      #    transfer logging = yes
+      #    log file = /dev/stdout
+      #    ignore nonreadable = yes
+      #    dont compress   = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2
+      #    port = 873
+      #    motd file = /etc/jenkins.motd
+      #
+      #    # Timeout in seconds
+      #    timeout = 300
+      #
+      #    # Any attempted uploads will fail
+      #    read only = true 
+      #
+      #    # Downloads will be possible if file permissions on the daemon side allow them
+      #    write only = false
+      #
+      #    hosts allow = localhost, get.jenkins.io, mirrors.jenkins-ci.org,172.16.0.0/12,10.0.0.0/8,192.168.0.0/16
+    jenkinsMotd:
+      override: false
+      # content: |-
+      #    [jenkins]
+      #    path = /srv/releases/jenkins
+      #    comment = "Jenkins Read-Only Mirror"
+      #    ========================
+      #    ==== JENKINS MIRROR ====
+      #    ========================
+      #
+      #    **Read Only**
+      #
+      #    Feel free to reach out on https://www.jenkins.io/chat/#jenkins-infra/ with any question you may have


### PR DESCRIPTION
This PR add the possibility to set the content of https://github.com/jenkins-infra/docker-rsyncd/blob/main/config/rsyncd.conf and https://github.com/jenkins-infra/docker-rsyncd/blob/main/config/jenkins.motd