### PR TITLE
fix(check-chart-versions-bump): correct `output` names

### DIFF
--- a/.github/workflows/check-chart-versions-bump.yml
+++ b/.github/workflows/check-chart-versions-bump.yml
@@ -36,7 +36,7 @@ jobs:
           git fetch --quiet origin ${{ github.event.pull_request.base.ref }}:target-branch
 
           # Set IFS to a comma to split the string into an array
-          IFS=',' read -ra chartNames <<< "${{ steps.list_modified_charts.outputs.modified_charts_with_unit_tests }}"
+          IFS=',' read -ra chartNames <<< "${{ steps.list_modified_charts.outputs.modified_charts }}"
 
           notBumped=0
 


### PR DESCRIPTION
Fix of #620 🤦 