### PR TITLE
fix(mirrorbits) correct container image name tag and digest usages

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.61.0
+version: 0.61.1

--- a/charts/mirrorbits/templates/deployment.rsyncd.yaml
+++ b/charts/mirrorbits/templates/deployment.rsyncd.yaml
@@ -34,10 +34,10 @@ spec:
               protocol: TCP
           livenessProbe:
             tcpSocket:
-             port: 873
+              port: 873
           readinessProbe:
             tcpSocket:
-             port: 873
+              port: 873
           resources:
             {{- toYaml .Values.rsyncd.resources | nindent 12 }}
           volumeMounts:

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -11,11 +11,11 @@ image:
     tag: 0.1.96
     pullPolicy: IfNotPresent
   files:
-    repository: httpd@sha256
-    tag: 18427eed921af003c951b5c97f0bde8a6df40cc7cb09b9739b9e35041a3c3acd
+    repository: httpd
+    tag: 2.4@sha256:18427eed921af003c951b5c97f0bde8a6df40cc7cb09b9739b9e35041a3c3acd
     pullPolicy: IfNotPresent
   rsyncd:
-    repository: jenkinsciinfra/rsyncd@sha256
+    repository: jenkinsciinfra/rsyncd
     tag: latest@sha256:ab76cbaa200f914d69cce68ee771e40aced3627740796e9e31845d7c883f0a67
     pullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -158,7 +158,7 @@ rsyncd:
       #    timeout = 300
       #
       #    # Any attempted uploads will fail
-      #    read only = true 
+      #    read only = true
       #
       #    # Downloads will be possible if file permissions on the daemon side allow them
       #    write only = false

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -28,9 +28,6 @@ sources:
       image: "httpd"
       tag: "2.4"
       architecture: "amd64"
-      hidetag: true
-    transformers:
-      - trimprefix: '@sha256:'
   latestGeoIPRelease:
     name: Get latest version of GeoIP
     kind: githubrelease
@@ -46,8 +43,6 @@ sources:
       image: "jenkinsciinfra/rsyncd"
       tag: "latest"
       architecture: "amd64"
-    transformers:
-      - trimprefix: '@sha256:'
 
 conditions:
   checkMirrorbitsDockerImagePublished:


### PR DESCRIPTION
The PR https://github.com/jenkins-infra/kubernetes-management/pull/4286 shows that the version `0.61.0` of the `mirrorbits` chart is setting up incorrect container image and tag names:

```diff
       containers:
          - name: rsyncd
-           image: "jenkinsciinfra/rsyncd@sha256:bc5b180219c491e514234ad1c7274f53cf8161c4be90be86dae9231f843e8417"
+           image: "jenkinsciinfra/rsyncd@sha256:latest@sha256:ab76cbaa200f914d69cce68ee771e40aced3627740796e9e31845d7c883f0a67"
            imagePullPolicy: IfNotPresent
            ports:
```

https://github.com/jenkins-infra/helm-charts/pull/611 was not enough so let's fix the `mirrorbits` chart