### PR TITLE
fix(mirrorbits[-lite]): set default empty secret values

### DIFF
--- a/charts/mirrorbits-lite/Chart.yaml
+++ b/charts/mirrorbits-lite/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Mirrobits lite helm chart for Kubernetes
 name: mirrorbits-lite
-version: 0.0.1
+version: 0.0.2

--- a/charts/mirrorbits-lite/templates/secret.yaml
+++ b/charts/mirrorbits-lite/templates/secret.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.conf -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,8 +6,7 @@ metadata:
 type: Opaque
 data:
   mirrorbits.conf: {{ .Values.conf | b64enc }}
-{{- end -}}
-{{ if .Values.geoipupdate -}}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -18,7 +16,7 @@ type: Opaque
 data:
   GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geoipupdate.account_id | b64enc }}
   GEOIPUPDATE_LICENSE_KEY: {{ .Values.geoipupdate.license_key | b64enc }}
-{{- end -}}
+
 {{ if .Values.repository.secrets.enabled -}}
 ---
 apiVersion: v1

--- a/charts/mirrorbits-lite/values.yaml
+++ b/charts/mirrorbits-lite/values.yaml
@@ -68,12 +68,12 @@ geoipupdate:
   image:
     repository: maxmindinc/geoipupdate
     tag: v6.0.0
-  # Secret values commented below for reference:
-  #account_id:
-  #license_key:
+  # Secret values, set to empty below for reference:
+  account_id: ""
+  license_key: ""
   editions: GeoLite2-ASN GeoLite2-City GeoLite2-Country
   update_frequency: 24
-# Accept the mirrorbits.conf data
+# mirrorbits.conf data, to be completed as secret with Redis credentials
 conf: |
   Repository: /srv/repo
   Templates: /usr/share/mirrorbits/templates

--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.65.0
+version: 0.65.1

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -80,13 +80,13 @@ geoipupdate:
   image:
     repository: maxmindinc/geoipupdate
     tag: v6.0.0
-  # Secret values commented below for reference:
-  #account_id:
-  #license_key:
+  # Secret values, set to empty below for reference:
+  account_id: ""
+  license_key: ""
   editions: GeoLite2-ASN GeoLite2-City GeoLite2-Country
   update_frequency: 24
 mirrorbits:
-  # Accept the mirrorbits.conf data
+  # mirrorbits.conf data, to be completed as secret with Redis credentials
   conf: |
     Repository: /srv/repo
     Templates: /usr/share/mirrorbits/templates


### PR DESCRIPTION
This PR fixes the error encountered when templating mirrorbits(-lite) secret with `helm template charts/mirrorbits`:
> Error: template: mirrorbits/templates/secret.yaml:17:62: executing "mirrorbits/templates/secret.yaml" at <b64enc>: invalid value; expected string

It also removes the conditions in mirrorbits-lite secret, not needed.