### PR TITLE
fix(httpd): default httpd.conf value

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.0.1
+version: 0.0.2

--- a/charts/httpd/templates/secret.yaml
+++ b/charts/httpd/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "httpd.fullname" . }}
 type: Opaque
 data:
-  httpd.conf: {{ .Values.httpd.conf | b64enc }}
+  httpd.conf: {{ .Values.conf | b64enc }}
 
 {{ if $.Values.repository.secrets.enabled -}}
 ---

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -75,6 +75,11 @@ repository:
     enabled: false
     # data hold secrets data used by persistentVolume
     data: {}
+# httpd.conf data, to be completed as secret with Redis credentials
+conf: |
+  Repository: /srv/repo
+  Templates: /usr/share/mirrorbits/templates
+  RedisAddress: mirrors-redis-master:6379
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
This PR fixes the following error:
> Error: template: httpd/templates/secret.yaml:8:24: executing "httpd/templates/secret.yaml" at <.Values.httpd.conf>: nil pointer evaluating interface {}.conf

Keeping mirrorbits chart default value, could probably be improved in a cleanup PR.