### PR TITLE
fix(httpd): remove unused `httpd.conf` secret

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.0.4
+version: 0.0.3

--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.0.2
+version: 0.0.4

--- a/charts/httpd/templates/secret.yaml
+++ b/charts/httpd/templates/secret.yaml
@@ -1,12 +1,3 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "httpd.fullname" . }}
-type: Opaque
-data:
-  httpd.conf: {{ .Values.conf | b64enc }}
-
 {{ if $.Values.repository.secrets.enabled -}}
 ---
 apiVersion: v1


### PR DESCRIPTION
This PR removes the `httpd.conf` secret, not used as this conf is already defined as configmap, comes from a mistake while extracting the chart from mirrorbits in #641 