### PR TITLE
chore(updatecli) fix httpd and rsyncd manifest to track their respective charts

### DIFF
--- a/updatecli/updatecli.d/httpd.yaml
+++ b/updatecli/updatecli.d/httpd.yaml
@@ -30,7 +30,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/httpd
-      key: $.image.files.tag
+      key: $.image.tag
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/rsyncd.yaml
+++ b/updatecli/updatecli.d/rsyncd.yaml
@@ -30,7 +30,7 @@ targets:
     kind: helmchart
     spec:
       name: charts/rsyncd
-      key: $.image.rsyncd.tag
+      key: $.image.tag
     scmid: default
 
 actions:


### PR DESCRIPTION
Fixes updatecli manifest following up #639 and #641 