### PR TITLE
fix(release): add `jenkins-infra` helm repository before running chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+      # Needed for mirrorbits-parent subchart dependencies
+      - name: Add jenkins-infra Helm repository
+        run: helm add jenkins-infra https://jenkins-infra.github.io/helm-charts
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:


### PR DESCRIPTION
Supersedes #677 to fix this error:

https://github.com/jenkins-infra/helm-charts/actions/runs/6111992877/job/16588472488
```
Run helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968
Run owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
Looking up latest tag...
Discovering changed charts since 'rsyncd-0.0.3'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.5.0/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/mirrorbits-parent'...
Error: no repository definition for https://jenkins-infra.github.io/helm-charts, https://jenkins-infra.github.io/helm-charts, https://jenkins-infra.github.io/helm-charts
Usage:
  cr package [CHART_PATH] [...] [flags]
```