### PR TITLE
chore(updatecli/rsyncd): use `patch` as versionincrement

### DIFF
--- a/updatecli/updatecli.d/rsyncd.yaml
+++ b/updatecli/updatecli.d/rsyncd.yaml
@@ -40,6 +40,7 @@ targets:
     spec:
       name: charts/rsyncd
       key: $.image.tag
+      versionincrement: patch
     scmid: default
 
 actions:


### PR DESCRIPTION
Like the other charts.

Noticed in #683 