### PR TITLE
fix(rsyncd) allow running as non root by specifying an internal port > 1024

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 1.1.0
+version: 1.1.1

--- a/charts/rsyncd/templates/configmap.rsyncd-conf.yaml
+++ b/charts/rsyncd/templates/configmap.rsyncd-conf.yaml
@@ -15,6 +15,8 @@ data:
     write only = false
 
     motd file = {{ .Values.configuration.motd.path }}
+
+    port = {{ .Values.port }}
   jenkins.motd: |-
 {{ .Values.configuration.motd.content | nindent 4 }}
 {{- range .Values.configuration.components }}

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -37,14 +37,14 @@ spec:
           {{- end }}
           ports:
             - name: rsyncd
-              containerPort: 873
+              containerPort: {{ .Values.port }}
               protocol: TCP
           livenessProbe:
             tcpSocket:
-              port: 873
+              port: {{ .Values.port }}
           readinessProbe:
             tcpSocket:
-              port: 873
+              port: {{ .Values.port }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/rsyncd/templates/service.yaml
+++ b/charts/rsyncd/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 873
+      targetPort: {{ .Values.port }}
       protocol: TCP
       name: rsyncd
   selector:

--- a/charts/rsyncd/tests/custom_values_test.yaml
+++ b/charts/rsyncd/tests/custom_values_test.yaml
@@ -1,47 +1,59 @@
 suite: Tests with custom values
+# Custom values used to test all suites from this file
+set:
+  image:
+    pullPolicy: Always
+  podSecurityContext:
+    fsGroup: 2000
+  containerSecurityContext:
+    runAsNonRoot: true
+  nodeSelector:
+    os: windows-2022
+  affinity:
+    podAntiAffinity:
+      foo: bar
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+  resources:
+    limits:
+      cpu: 500m
+    requests:
+      memory: 1024Mi
+  port: 9999
+  service:
+    port: 2873
+    type: LoadBalancer
+    LoadBalancerIP: 1.2.3.4
+    whitelisted_sources:
+      - 52.167.253.43/32
+      - 52.202.51.185/32
+  configuration:
+    motd:
+      path: /tmp/motd
+      content: |-
+        ==========
+        FOO BAR
+        SUPER MOTD
+        ==========
+    components:
+      - name: jenkins
+        path: /rsyncd/data/jenkins
+        comment: "Jenkins Read-Only Mirror"
+        volume:
+          persistentVolumeClaim:
+            claimName: super-pvc
+      - name: hudson
+        path: /tmp/hudson
+        comment: "Hudson Read-Only Mirror"
+        volume:
+          persistentVolumeClaim:
+            claimName: another-vol
 tests:
   - it: should define a customized "rsyncd" deployment
     template: deployment.yaml
-    set:
-      image:
-        pullPolicy: Always
-      podSecurityContext:
-        fsGroup: 2000
-      containerSecurityContext:
-        runAsNonRoot: true
-      nodeSelector:
-        os: windows-2022
-      affinity:
-        podAntiAffinity:
-          foo: bar
-      tolerations:
-        - key: "kubernetes.io/arch"
-          operator: "Equal"
-          value: "arm64"
-          effect: "NoSchedule"
-      resources:
-        limits:
-          cpu: 500m
-        requests:
-          memory: 1024Mi
-      service:
-        port: 2873
-      configuration:
-        motd:
-          path: /tmp/motd
-        components:
-          - name: jenkins
-            path: /rsyncd/data/jenkins
-            comment: "Jenkins Read-Only Mirror"
-            volume:
-              persistentVolumeClaim:
-                claimName: super-pvc
-          - name: hudson
-            path: /tmp/hudson
-            comment: "Hudson Read-Only Mirror"
-            volume:
-              persistentVolumeClaim:
-                claimName: another-vol
     asserts:
       - hasDocuments:
           count: 1
@@ -77,10 +89,10 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].effect
           value: "NoSchedule"
-      # Exposed port is always 873
+      # Custom exposed port
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
-          value: 873
+          value: 9999
       # Custom container resources
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -175,28 +187,6 @@ tests:
           value: true
   - it: should create a custom rsyncd-conf config map
     template: configmap.rsyncd-conf.yaml
-    set:
-      configuration:
-        motd:
-          path: /tmp/motd
-          content: |-
-            ==========
-            FOO BAR
-            SUPER MOTD
-            ==========
-        components:
-          - name: jenkins
-            path: /rsyncd/data/jenkins
-            comment: "Jenkins Read-Only Mirror"
-            volume:
-              persistentVolumeClaim:
-                claimName: super-pvc
-          - name: hudson
-            path: /tmp/hudson
-            comment: "Hudson Read-Only Mirror"
-            volume:
-              persistentVolumeClaim:
-                claimName: another-vol
     asserts:
       - hasDocuments:
           count: 1
@@ -223,16 +213,11 @@ tests:
       - matchRegex:
           path: data["jenkins.motd"]
           pattern: SUPER MOTD
+      - matchRegex:
+          path: data["rsyncd.inc"]
+          pattern: port = 9999
   - it: should create the default service
     template: service.yaml
-    set:
-      service:
-        port: 2873
-        type: LoadBalancer
-        LoadBalancerIP: 1.2.3.4
-        whitelisted_sources:
-          - 52.167.253.43/32
-          - 52.202.51.185/32
     asserts:
       - hasDocuments:
           count: 1
@@ -251,10 +236,14 @@ tests:
       - equal:
           path: spec.loadBalancerSourceRanges[1]
           value: 52.202.51.185/32
-      # Custom port
+      # Custom published port
       - equal:
           path: spec.ports[0].port
           value: 2873
+      # Default exposed (pod) port is 1873 by default
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9999
       # Check the expected label selectors to allow Service to catch the pods
       - equal:
           path: spec.selector["app.kubernetes.io/name"]

--- a/charts/rsyncd/tests/defaults_test.yaml
+++ b/charts/rsyncd/tests/defaults_test.yaml
@@ -35,10 +35,10 @@ tests:
       # No tolerations by default
       - notExists:
           path: spec.template.spec.tolerations
-      # Default exposed port is 873
+      # Default exposed port is 1873
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
-          value: 873
+          value: 1873
       # No container resources by default
       - notExists:
           path: spec.template.spec.containers[0].resources
@@ -90,6 +90,9 @@ tests:
       - matchRegex:
           path: data["rsyncd.inc"]
           pattern: motd file = /etc/rsyncd/jenkins.motd
+      - matchRegex:
+          path: data["rsyncd.inc"]
+          pattern: port = 1873
       - notExists:
           path: data["jenkins.conf"]
       - matchRegex:
@@ -113,10 +116,14 @@ tests:
           path: spec.loadBalancerIP
       - notExists:
           path: spec.loadBalancerSourceRanges
-      # Default port is 873
+      # Default published port is 873 by default
       - equal:
           path: spec.ports[0].port
           value: 873
+      # Default exposed (pod) port is 1873 by default
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 1873
       # Check the expected label selectors to allow Service to catch the pods
       - equal:
           path: spec.selector["app.kubernetes.io/name"]

--- a/charts/rsyncd/values.yaml
+++ b/charts/rsyncd/values.yaml
@@ -17,8 +17,13 @@ containerSecurityContext: {}
 # readOnlyRootFilesystem: true
 # runAsNonRoot: true
 # runAsUser: 1000
+
+# (privately exposed) port of the pod. Should be > 1024 as the container should run as non root
+port: 1873
+
 service:
   type: ClusterIP
+  # Port published by the "Service". Maps to the pod (privately exposed) port
   port: 873
   # LoadBalancerIP: 1.2.3.4
   whitelisted_sources: []


### PR DESCRIPTION
While trying to execute `rsyncd` with the new 1.x image (which default user is the unprivileged `nobody`), the `rsync`  process is failing with exit code `10` (I/O error) as caught by @lemeurherve .

After a `strace`, we saw the error `bind(4, {sa_family=AF_INET, sin_port=htons(873), sin_addr=inet_addr("0.0.0.0")}, 16) = -1 EACCES (Permission denied)`: the default port 873 requires privileged access.

This PR fixes the helm chart to use another pod exposed port to bypass this problem: a new value `port` is introduced, defaulted to `1873` (symmetry with the port published by the Kubernetes Service for `rsyncd`).
The `rsync.inc` file is used to override the default setup from the container image.

Note: the custom values specified in the unit test have been factorized to avoid cherry-picking values across the test suites of a given file.