### PR TITLE
fix(rsyncd) mount motd in the configuration directory

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 1.2.0
+version: 1.2.1

--- a/charts/rsyncd/tests/defaults_test.yaml
+++ b/charts/rsyncd/tests/defaults_test.yaml
@@ -67,7 +67,7 @@ tests:
           value: "jenkins.motd"
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].mountPath
-          value: /etc/rsyncd/jenkins.motd
+          value: /etc/rsyncd.d/jenkins.motd
       # TempFS volume by default
       -  equal:
           path: spec.template.spec.volumes[1].name
@@ -119,7 +119,7 @@ tests:
           value: RELEASE-NAME-rsyncd-conf
       - matchRegex:
           path: data["rsyncd.inc"]
-          pattern: motd file = /etc/rsyncd/jenkins.motd
+          pattern: motd file = /etc/rsyncd.d/jenkins.motd
       - matchRegex:
           path: data["rsyncd.inc"]
           pattern: port = 1873

--- a/charts/rsyncd/values.yaml
+++ b/charts/rsyncd/values.yaml
@@ -45,7 +45,7 @@ tolerations: []
 affinity: {}
 configuration:
   motd:
-    path: /etc/rsyncd/jenkins.motd
+    path: /etc/rsyncd.d/jenkins.motd
     content: |-
       ========================
       ==== JENKINS MIRROR ====


### PR DESCRIPTION
Caught while pairing with @lemeurherve : the mount path should be inside the `/etc/rsyncd.d` directory.