### PR TITLE
chore(updatecli) fix wiki chart image architecture to use 'arm64'

### DIFF
--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -29,7 +29,9 @@ conditions:
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/wiki"
-      architecture: "amd64"
+      architectures:
+        - amd64
+        - arm64
 
 targets:
   updateChart:


### PR DESCRIPTION
Please note that this PR won't have any effect until https://github.com/updatecli/updatecli/issues/1582 is fixed and deployed to jenkins infra