### PR TITLE
feat(mirrorbits) use a volume for logs

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: me@olblak.com
   name: olblak
 name: mirrorbits
-version: 0.65.4
+version: 0.66.0

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -37,12 +37,14 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: /etc/mirrorbits
+            - name: geoipdata
+              mountPath: /usr/share/GeoIP
+            - name: logs
+              mountPath: /var/logs/mirrorbits
             {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
             - name: binary
               mountPath: /srv/repo
             {{- end }}
-            - name: geoipdata
-              mountPath: /usr/share/GeoIP
           livenessProbe:
             httpGet:
               path: /?mirrorstats
@@ -111,8 +113,10 @@ spec:
                 path: mirrorbits.conf
         - name: geoipdata
           emptyDir: {}
-        {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
+        - name: logs
+          {{- toYaml .Values.mirrorbits.logs.volume | nindent 10 }}
+        {{- if $.Values.repository.persistentVolumeClaim.enabled }}
         - name: binary
           persistentVolumeClaim:
             claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
-        {{- end -}}
+        {{- end }}

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -1,6 +1,28 @@
 suite: Tests with custom values
-values:
-  - secrets_default_values.yaml
+set:
+  fullNameOverride: "my-fullNameOverride"
+  ingress:
+    enabled: true
+    hosts:
+      - host: chart-example.local
+        paths:
+        - path: /
+          pathType: IfNotPresent
+  image:
+    files:
+      pullPolicy: Never
+    mirrorbits:
+      pullPolicy: Always
+  geoipupdate:
+    account_id: my-account-id
+    license_key: my-license-key
+  rsyncd:
+    enabled: true
+  mirrorbits:
+    logs:
+      volume:
+        persistentVolumeClaim:
+          claimName: foobar
 templates:
   - deployment.yaml
   - deployment.files.yaml
@@ -12,8 +34,6 @@ templates:
 tests:
   - it: Should set the correct service selector labels when a fullNameOverride is specified
     template: service.files.yaml
-    set:
-      fullNameOverride: "my-fullNameOverride"
     asserts:
       - hasDocuments:
           count: 1
@@ -28,6 +48,7 @@ tests:
   - it: Should set the correct service selector labels when a nameOverride is specified
     template: service.files.yaml
     set:
+      # Overides the fullname overide \o/
       nameOverride: "my-nameOverride"
     asserts:
       - hasDocuments:
@@ -42,10 +63,6 @@ tests:
           value: "RELEASE-NAME-files"
   - it: should define a customized "files" deployment
     template: deployment.files.yaml
-    set:
-      image:
-        files:
-          pullPolicy: Never
     asserts:
       - hasDocuments:
           count: 1
@@ -56,10 +73,6 @@ tests:
           value: Never
   - it: should define a customized "mirrorbits" deployment
     template: deployment.yaml
-    set:
-      image:
-        mirrorbits:
-          pullPolicy: Always
     asserts:
       - hasDocuments:
           count: 1
@@ -68,16 +81,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[*].imagePullPolicy
           value: Always
+      # Log volumes is a custom PVC
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: logs
+      - equal:
+          path: spec.template.spec.volumes[2].persistentVolumeClaim.claimName
+          value: foobar
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].name
+          value: logs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /var/logs/mirrorbits
   - it: should create ingress with pathType set to the specified custom value by default
     template: ingress.yaml
-    set:
-      ingress:
-        enabled: true
-        hosts:
-          - host: chart-example.local
-            paths:
-            - path: /
-              pathType: IfNotPresent
     asserts:
       - hasDocuments:
           count: 1
@@ -86,25 +104,8 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].pathType
           value: "IfNotPresent"
-  - it: should define a customized "mirrorbits" deployment
-    template: deployment.yaml
-    set:
-      image:
-        mirrorbits:
-          pullPolicy: Always
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Deployment
-      - equal:
-          path: spec.template.spec.containers[*].imagePullPolicy
-          value: Always
   - it: should create rsyncd deployment if rsyncd is enabled
     template: deployment.rsyncd.yaml
-    set:
-      rsyncd:
-        enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -112,9 +113,6 @@ tests:
           of: Deployment
   - it: should create rsyncd service if rsyncd is enabled
     template: service.rsyncd.yaml
-    set:
-      rsyncd:
-        enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -1,6 +1,5 @@
 suite: Tests with custom values
 set:
-  fullNameOverride: "my-fullNameOverride"
   ingress:
     enabled: true
     hosts:
@@ -34,6 +33,8 @@ templates:
 tests:
   - it: Should set the correct service selector labels when a fullNameOverride is specified
     template: service.files.yaml
+    set:
+      fullNameOverride: "my-fullNameOverride"
     asserts:
       - hasDocuments:
           count: 1
@@ -48,7 +49,6 @@ tests:
   - it: Should set the correct service selector labels when a nameOverride is specified
     template: service.files.yaml
     set:
-      # Overides the fullname overide \o/
       nameOverride: "my-nameOverride"
     asserts:
       - hasDocuments:

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -1,7 +1,4 @@
 suite: default tests
-values:
-  - ../values.yaml
-  - secrets_default_values.yaml
 templates:
   - deployment.yaml
   - deployment.files.yaml
@@ -33,24 +30,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should create ingress with pathType set to Prefix by default
-    template: ingress.yaml
-    set:
-      ingress:
-        enabled: true
-        hosts:
-          - host: chart-example.local
-            paths:
-            - path: /
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - equal:
-          path: spec.rules[0].http.paths[0].pathType
-          value: "Prefix"
-  - it: should set the correct service selector labels
+  - it: should set the correct service "files" selector labels
     template: service.files.yaml
     asserts:
       - hasDocuments:
@@ -62,19 +42,6 @@ tests:
           value: "mirrorbits-files"
       - equal:
           path: spec.selector["app.kubernetes.io/instance"]
-          value: "RELEASE-NAME-files"
-  - it: Should set the correct deployment metadata labels
-    template: deployment.files.yaml
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Deployment
-      - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/name"]
-          value: "mirrorbits-files"
-      - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
           value: "RELEASE-NAME-files"
   - it: should define the default "files" deployment with default imagePullPolicy and metadata labels
     template: deployment.files.yaml
@@ -92,3 +59,32 @@ tests:
       - equal:
           path: "spec.template.spec.containers[*].imagePullPolicy"
           value: IfNotPresent
+  - it: should define the default "mirrorbits" deployment with default imagePullPolicy and metadata labels
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: "mirrorbits"
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: "RELEASE-NAME"
+      - equal:
+          path: "spec.template.spec.containers[*].imagePullPolicy"
+          value: IfNotPresent
+      # Log volumes is an emptydir by default
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: logs
+      - equal:
+          path: spec.template.spec.volumes[2].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].name
+          value: logs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /var/logs/mirrorbits

--- a/charts/mirrorbits/tests/secrets_default_values.yaml
+++ b/charts/mirrorbits/tests/secrets_default_values.yaml
@@ -1,3 +1,0 @@
-geoipupdate:
-  account_id: my-account-id
-  license_key: my-license-key

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -89,7 +89,7 @@ mirrorbits:
   logs:
     volume:
       emptyDir: {}
-      ## Volume contains the Pod Volume definition. For an existing PVC for instance:
+      ## Volume contains the Pod Volume definition. Example with an existing PVC:
       # persistentVolumeClaim:
       #   claimName: <PVC name>
   ## mirrorbits.conf data, to be completed as secret with Redis credentials

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -86,7 +86,13 @@ geoipupdate:
   editions: GeoLite2-ASN GeoLite2-City GeoLite2-Country
   update_frequency: 24
 mirrorbits:
-  # mirrorbits.conf data, to be completed as secret with Redis credentials
+  logs:
+    volume:
+      emptyDir: {}
+      ## Volume contains the Pod Volume definition. For a PVC:
+      # persistentVolumeClaim:
+      #   claimName: <PVC name>
+  ## mirrorbits.conf data, to be completed as secret with Redis credentials
   conf: |
     Repository: /srv/repo
     Templates: /usr/share/mirrorbits/templates

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -89,7 +89,7 @@ mirrorbits:
   logs:
     volume:
       emptyDir: {}
-      ## Volume contains the Pod Volume definition. For a PVC:
+      ## Volume contains the Pod Volume definition. For an existing PVC for instance:
       # persistentVolumeClaim:
       #   claimName: <PVC name>
   ## mirrorbits.conf data, to be completed as secret with Redis credentials


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3136, I had to enable the download logs on mirrorbits.
These logs are written in the container root which is a bad practice (for performance at least).

This PR ensures that the logs directory of mirrorbits deployment is set as a data volume, emptydir by default.


- Added unit tests
- Installed on a local k3s (smoke test only: I haven't checked if the logs are writtenà)
- Tried a helmfile diff with production: it only changes the version in metadata and set the emptydir volume in the pod (no other changes)

(edit after first code review) This PR also updates the "custom values" test harness to factorize the values on top of the file. Not strictly mandatory but it helped me to properly set up my unit test case (as part of TDD steps).
Exception for the name overrides which are having a behavior we don't fully understand yet: subject of another PR.