### PR TITLE
fix(mirrorbits) correct the mountpath to the real location 

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.5.2
 description: Mirrobits helm chart for Kubernetes
 maintainers:
-- email: me@olblak.com
-  name: olblak
+- email: jenkins-infra-team@googlegroups.com
+  name: jenkins-infra-team
 name: mirrorbits
-version: 0.66.0
+version: 0.66.1

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: geoipdata
               mountPath: /usr/share/GeoIP
             - name: logs
-              mountPath: /var/logs/mirrorbits
+              mountPath: /var/log/mirrorbits
             {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
             - name: binary
               mountPath: /srv/repo

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -93,7 +93,7 @@ tests:
           value: logs
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
-          value: /var/logs/mirrorbits
+          value: /var/log/mirrorbits
   - it: should create ingress with pathType set to the specified custom value by default
     template: ingress.yaml
     asserts:

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -87,4 +87,4 @@ tests:
           value: logs
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
-          value: /var/logs/mirrorbits
+          value: /var/log/mirrorbits


### PR DESCRIPTION
TL;DR;

`s#/var/logs/#/var/log` because /me was not paying attention 🥲