### PR TITLE
fix(mirrorbits) remove unneeded service account

### DIFF
--- a/charts/mirrorbits/README.md
+++ b/charts/mirrorbits/README.md
@@ -28,8 +28,6 @@ https://get.jenkins.io/windows/2.251/jenkins.msi.sha256?stats
 `nameOverride`:
 `fullnameOverride`:
 `imagePullSecrets`:
-`serviceAccount.create`:
-`serviceAccount.name`:
 `securityContext`:
 `podSecurityContext`:
 `service.type`:
@@ -60,11 +58,11 @@ This chart requires a redis database which can be deployed with the redis helm [
 
 ## HowTo
 
-Mirrorbits is configured using its cli. The configuration is stored in the redis database which means that you can either store a configuration 
+Mirrorbits is configured using its cli. The configuration is stored in the redis database which means that you can either store a configuration
 locally and run the cli from your machine or you can connect inside one of the pod running to use the cli.
 
 ### Access mirrobits cli
- 
+
 You need to first identify a pod name and then run a bash command inside it.
 
 * ```kubectl get pods -n mirrorbits -l "app.kubernetes.io/name=mirrorbits"```

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -43,14 +43,3 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "mirrorbits.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "mirrorbits.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}

--- a/charts/mirrorbits/templates/deployment.rsyncd.yaml
+++ b/charts/mirrorbits/templates/deployment.rsyncd.yaml
@@ -21,7 +21,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "mirrorbits.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "mirrorbits.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/mirrorbits/templates/serviceaccount.yaml
+++ b/charts/mirrorbits/templates/serviceaccount.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.serviceAccount.create -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "mirrorbits.serviceAccountName" . }}
-  labels:
-{{ include "mirrorbits.labels" . | indent 4 }}
-{{- end -}}

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -21,12 +21,6 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: false
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: null
 podSecurityContext: {}
 # fsGroup: 2000
 securityContext: {}


### PR DESCRIPTION
Kubernetes Service Accounts are only required to interact with a Kubernetes API.

The mirrorbits service (and the associated httpd and rsync components) have no need to access it.

This PR removes any reference to the service account as it was created by the default helm template.

💡 Please note:

- A subsequent PR will remove the service account from the template to avoid propagating this "insane" default
- This PR needs a "twin" for `mirrorbits-lite`
- One PR per chart is required to remove SVC accounts