### PR TITLE
docs(mirrorbit-parents) improve documentation

### DIFF
--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 dependencies:
 - name: mirrorbits-lite
   condition: mirrorbits-lite.enabled

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -1,0 +1,102 @@
+# Mirrorbits Parent (All-in-one Mirrorbits shaped for the Jenkins project)
+
+This chart allows to deploys up to three services:
+
+* [mirrorbits](https://github.com/etix/mirrorbits) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits-lite>
+* [httpd (Apache2)](https://httpd.apache.org/) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/httpd>
+* [rsyncd](https://linux.die.net/man/1/rsync) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/rsyncd>
+
+The goal is to deploy either an "HTTP redirector" service centered on [mirrorbits](https://github.com/etix/mirrorbits) and/or a Jenkins download mirror.
+
+## Requirements
+
+This chart has the same requirements as any of the 3 sub-charts.
+
+## Settings (Values)
+
+Look at the [`values.yaml` source file](./values.yaml) to get the possible configuration values.
+
+### Ingress
+
+If you need to provide an ingress to route request to a mix of the sub services, then you can specify the ingress configuration through this parent chart (instead of the sub-charts).
+
+Example to define an Nginx ingress on the domain `downloads.company.org` with TLS enabled (managed by Let's Encrypt),
+where all URLs ending with a `zip` or `gz` string are redirected to the mirrorbits backend,
+and the other requests to httpd:
+
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/use-regex": "true"
+  hosts:
+    - host: downloads.company.org
+      paths:
+        - path: /
+          backendService: httpd
+        - path: /.*[.](zip|gz)$
+          backendService: mirrorbits
+  tls:
+    - secretName: ingress-certificates
+      hosts:
+        - downloads.company.org
+
+mirrorbits-lite:
+  enabled: true
+
+httpd:
+  enabled: true
+```
+
+### Storage
+
+This chart is usually deployed with the same persistent storage for all the sub-services.
+As such you can manage a common persistent volume (and associated claims) once and for all instead of delegating to the sub-charts.
+
+Since the chart is initially designed to run on AKS with an Azurefile volume, part of the PV/PVC configuration can be managed (CSI setup, Azurefile secret for the access key)
+through the `storage.persistentVolume.azureFile` value.
+
+Example with an Azure file PV and associated PVC mounted in read only:
+
+```yaml
+mirrorbits-lite:
+  enabled: true
+  repository:
+    name: <name of the PVC>
+    reuseExistingPersistentVolumeClaim: true
+
+httpd:
+  enabled: true
+  repository:
+    name: <name of the PVC>
+    reuseExistingPersistentVolumeClaim: true
+
+storage:
+  enabled: true
+  storageClassName: azurefile-csi-premium
+  storageSize: 100Gi
+  accessModes:
+    - ReadOnlyMany
+  persistentVolume:
+    azureFile:
+      ## Encrypt these values using helm-secrets/sops or whatever
+      storageAccountName: storage-account-name
+      storageAccountKey: StorageAccountSuperSecretKey
+      ## End of encrypted values
+      resourceGroup: storage-rg
+      shareName: storage-share-name
+      readOnly: true
+    additionalSpec:
+      persistentVolumeReclaimPolicy: Retain
+      mountOptions:
+        - dir_mode=0555
+        - file_mode=0444
+        - uid=1000
+        - gid=1000
+        - mfsymlinks
+        - nobrl
+        - serverino
+        - cache=strict
+```

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -55,8 +55,7 @@ httpd:
 This chart is usually deployed with the same persistent storage for all sub-services.
 As such you can manage a common persistent volume (and associated claims) once and for all instead of delegating to the sub-charts.
 
-Since the chart was initially designed to run on AKS with an Azurefile volume, part of the PV/PVC configuration can be managed (CSI setup, Azurefile secret for the access key)
-through the `storage.persistentVolume.azureFile` value.
+Since the chart was initially designed to run on AKS with an Azurefile volume, part of the PV/PVC configuration can be managed (CSI setup, Azurefile secret for the access key) through the `storage.persistentVolume.azureFile` value.
 
 Example with an Azure file PV and associated PVC mounted in read only:
 

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -2,15 +2,15 @@
 
 This chart allows to deploys up to three services:
 
-* [mirrorbits](https://github.com/etix/mirrorbits) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits-lite>
-* [httpd (Apache2)](https://httpd.apache.org/) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/httpd>
-* [rsyncd](https://linux.die.net/man/1/rsync) through the sub-chart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/rsyncd>
+* [mirrorbits](https://github.com/etix/mirrorbits) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits-lite>
+* [httpd (Apache2)](https://httpd.apache.org/) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/httpd>
+* [rsyncd](https://linux.die.net/man/1/rsync) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/rsyncd>
 
-The goal is to deploy either an "HTTP redirector" service centered on [mirrorbits](https://github.com/etix/mirrorbits) and/or a Jenkins download mirror.
+The goal is to deploy an "HTTP redirector" service centered on [mirrorbits](https://github.com/etix/mirrorbits) and/or a Jenkins download mirror.
 
 ## Requirements
 
-This chart has the same requirements as any of the 3 sub-charts.
+This chart has the same requirements as any of the 3 subcharts.
 
 ## Settings (Values)
 
@@ -18,11 +18,11 @@ Look at the [`values.yaml` source file](./values.yaml) to get the possible confi
 
 ### Ingress
 
-If you need to provide an ingress to route request to a mix of the sub services, then you can specify the ingress configuration through this parent chart (instead of the sub-charts).
+If you need to provide an ingress to route request to a mix of the sub services, then you can specify the ingress configuration through this parent chart (instead of the subcharts).
 
-Example to define an Nginx ingress on the domain `downloads.company.org` with TLS enabled (managed by Let's Encrypt),
+Example to define a nginx ingress on the domain `downloads.company.org` with TLS enabled (managed by Let's Encrypt),
 where all URLs ending with a `zip` or `gz` string are redirected to the mirrorbits backend,
-and the other requests to httpd:
+and the other requests to the httpd backend:
 
 ```yaml
 ingress:
@@ -52,10 +52,10 @@ httpd:
 
 ### Storage
 
-This chart is usually deployed with the same persistent storage for all the sub-services.
+This chart is usually deployed with the same persistent storage for all sub-services.
 As such you can manage a common persistent volume (and associated claims) once and for all instead of delegating to the sub-charts.
 
-Since the chart is initially designed to run on AKS with an Azurefile volume, part of the PV/PVC configuration can be managed (CSI setup, Azurefile secret for the access key)
+Since the chart was initially designed to run on AKS with an Azurefile volume, part of the PV/PVC configuration can be managed (CSI setup, Azurefile secret for the access key)
 through the `storage.persistentVolume.azureFile` value.
 
 Example with an Azure file PV and associated PVC mounted in read only:

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -21,7 +21,7 @@ Look at the [`values.yaml` source file](./values.yaml) to get the possible confi
 If you need to provide an ingress to route request to a mix of the sub services, then you can specify the ingress configuration through this parent chart (instead of the subcharts).
 
 Example to define a nginx ingress on the domain `downloads.company.org` with TLS enabled (managed by Let's Encrypt),
-where all URLs ending with a `zip` or `gz` string are redirected to the mirrorbits backend,
+where all request URLs ending with a `zip` or `gz` string are redirected to the mirrorbits backend,
 and the other requests to the httpd backend:
 
 ```yaml

--- a/charts/mirrorbits-parent/templates/_helpers.tpl
+++ b/charts/mirrorbits-parent/templates/_helpers.tpl
@@ -1,6 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Expand the name of the chart.
+Define the full "release" (e.g. chart installation) name.
+Must be 63 chars. maximum.
 */}}
 {{- define "mirrorbits-parent.name" -}}
 {{- $name := .Chart.Name -}}
@@ -13,13 +14,14 @@ Expand the name of the chart.
 
 {{/*
 Create chart name and version as used by the chart label.
+Must be 63 chars. maximum.
 */}}
 {{- define "mirrorbits-parent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Common labels
+Define the common labels.
 */}}
 {{- define "mirrorbits-parents.labels" -}}
 app.kubernetes.io/name: {{ include "mirrorbits-parent.name" . }}
@@ -32,7 +34,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Define the azure file persistent volume's secret name (if enabled).
+Must be 63 chars. maximum.
 */}}
 {{- define "mirrorbits-parent.pv-secretname" -}}
 {{- printf "%s-%s" (include "mirrorbits-parent.name" . | trunc 43 ) "persistentvolume-secret" -}}

--- a/charts/mirrorbits-parent/templates/persistentvolumesecret.yaml
+++ b/charts/mirrorbits-parent/templates/persistentvolumesecret.yaml
@@ -1,13 +1,13 @@
-{{ if and .Values.storage.persistentVolume.azureFile.storageAccountName .Values.storage.persistentVolume.azureFile.storageAccountKey -}}
+{{ with .Values.storage.persistentVolume.azureFile -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "mirrorbits-parent.pv-secretname" . }}
+  name: {{ include "mirrorbits-parent.pv-secretname" $ }}
   labels:
-{{ include "mirrorbits-parents.labels" . | nindent 4 }}
+{{ include "mirrorbits-parents.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  azurestorageaccountname: {{ .Values.storage.persistentVolume.azureFile.storageAccountName | b64enc }}
-  azurestorageaccountkey: {{ .Values.storage.persistentVolume.azureFile.storageAccountKey | b64enc }}
+  azurestorageaccountname: {{ .storageAccountName | b64enc }}
+  azurestorageaccountkey: {{ .storageAccountKey | b64enc }}
 {{- end -}}

--- a/charts/mirrorbits-parent/values.yaml
+++ b/charts/mirrorbits-parent/values.yaml
@@ -41,7 +41,7 @@ storage:
     - ReadOnlyMany
   persistentVolume:
     ## This chart usually runs on Azure with an Azurefile as a persistent volume.
-    ## Use the following section to help you define the secret and CSI specificatoion for the PV.
+    ## Use the following section to define the secret and CSI specification for the PV.
     # azureFile:
     #   resourceGroup: storage-rg
     #   storageAccountName: storage-account

--- a/charts/mirrorbits-parent/values.yaml
+++ b/charts/mirrorbits-parent/values.yaml
@@ -40,8 +40,8 @@ storage:
   accessModes:
     - ReadOnlyMany
   persistentVolume:
-    ## Generate Azurefile CSI definition in the PV spec
-    azureFile: {}
+    ## This chart usually runs on Azure with an Azurefile as a persistent volume.
+    ## Use the following section to help you define the secret and CSI specificatoion for the PV.
     # azureFile:
     #   resourceGroup: storage-rg
     #   storageAccountName: storage-account


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helm-charts/pull/774 post-merge review

- Adds a `README.md` documentating the umbrellas ingress and storages
- Fully comment out the `storage.persistentVolume.azureFile` value to avoid confusion
- Update helper template comments