### PR TITLE
fix(account-app) correct default values for 'resources' to avoid YAML parsing error

### DIFF
--- a/charts/accountapp/Chart.yaml
+++ b/charts/accountapp/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for accounts.jenkins.io
 maintainers:
 - name: timja
 name: accountapp
-version: 0.7.0
+version: 0.7.1

--- a/charts/accountapp/templates/deployment.yaml
+++ b/charts/accountapp/templates/deployment.yaml
@@ -100,8 +100,10 @@ spec:
                   path: /login
                   port: http
                   scheme: HTTP
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/accountapp/tests/custom_values_test.yaml
+++ b/charts/accountapp/tests/custom_values_test.yaml
@@ -27,3 +27,27 @@ tests:
       - equal:
           path: data.smtpPassword
           value: c210cC1wYXNzd29yZA==
+  - it: should create a Deployment with the customized values
+    set:
+      image:
+        pullPolicy: Always
+      resources:
+        limits:
+          memory: 1024Mi
+        requests:
+          cpu: 500m
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 500m

--- a/charts/accountapp/tests/defaults_test.yaml
+++ b/charts/accountapp/tests/defaults_test.yaml
@@ -19,3 +19,5 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
+      - notExists:
+          path: spec.template.spec.containers[0].resources

--- a/charts/accountapp/values.yaml
+++ b/charts/accountapp/values.yaml
@@ -29,8 +29,8 @@ ingress:
 #    - secretName: accounts-tls
 #      hosts:
 #        - accounts.jenkins.io
-resources: # We usually recommend not to specify default resources and to leave this as a conscious
-# choice for the user. This also increases chances charts run on environments with little
+# We usually recommend not to specify default resources and to leave this as a conscious: null # choice for the user. This also increases chances charts run on environments with little
+resources: {}
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
 # limits:


### PR DESCRIPTION
Thanks @olblak for catching the root issue ❤️ 

This PR fixes an issue when using the default value for `resources` which should be `{}` to ensure all YAML parser consider it as null.

Please note that I have a personal preference for commenting out the empty or undefined values on helm charts, but this fix will do.