### PR TITLE
feat(mirrorbits-lite) allow defining ingress and PV(C)s from parent chart

### DIFF
--- a/charts/mirrorbits-lite/.helmignore
+++ b/charts/mirrorbits-lite/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests/*

--- a/charts/mirrorbits-lite/Chart.yaml
+++ b/charts/mirrorbits-lite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits lite helm chart for Kubernetes
 name: mirrorbits-lite
-version: 0.2.1
+version: 0.3.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits-lite/templates/_helpers.tpl
+++ b/charts/mirrorbits-lite/templates/_helpers.tpl
@@ -43,3 +43,21 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Data directory volume definition. Might be defined from parent chart templates or autonomously
+based on the presence of the global value provided by the parent chart.
+*/}}
+{{- define "mirrorbits-lite.data-volume" -}}
+{{- if (dig "global" "storage" "enabled" false .Values.AsMap) -}}
+persistentVolumeClaim:
+  claimName: {{ include "mirrorbits-parent.pvc-name" . }}
+{{- else }}
+  {{- if .Values.repository.persistentVolumeClaim.enabled }}
+persistentVolumeClaim:
+  claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .)) }}
+  {{- else }}
+emptyDir: {}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mirrorbits-lite/templates/deployment.yaml
+++ b/charts/mirrorbits-lite/templates/deployment.yaml
@@ -41,10 +41,8 @@ spec:
               mountPath: /usr/share/GeoIP
             - name: logs
               mountPath: /var/log/mirrorbits
-            {{ if $.Values.repository.persistentVolumeClaim.enabled -}}
-            - name: binary
+            - name: data
               mountPath: /srv/repo
-            {{- end }}
           livenessProbe:
             httpGet:
               path: /?mirrorstats
@@ -114,8 +112,5 @@ spec:
           emptyDir: {}
         - name: logs
           {{- toYaml .Values.logs.volume | nindent 10 }}
-        {{- if $.Values.repository.persistentVolumeClaim.enabled }}
-        - name: binary
-          persistentVolumeClaim:
-            claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .)) }}
-        {{- end }}
+        - name: data
+          {{- include "mirrorbits-lite.data-volume" . | nindent 10}}

--- a/charts/mirrorbits-lite/templates/ingress.yaml
+++ b/charts/mirrorbits-lite/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not (dig "global" "ingress" "enabled" false .Values.AsMap)) -}}
 {{- $fullName := include "mirrorbits-lite.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/mirrorbits-lite/templates/mocks/_helpers.tpl
+++ b/charts/mirrorbits-lite/templates/mocks/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "mirrorbits-parent.pvc-name" -}}
+parent-chart-shared-data
+{{- end -}}

--- a/charts/mirrorbits-lite/templates/persistentVolume.yaml
+++ b/charts/mirrorbits-lite/templates/persistentVolume.yaml
@@ -1,11 +1,11 @@
-{{ if $.Values.repository.persistentVolume.enabled -}}
+{{ if and .Values.repository.persistentVolume.enabled (not (dig "global" "ingress" "enabled" false .Values.AsMap)) -}}
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .)) }}
+  name: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .)) }}
   labels:
-    data: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" . )) }}
+    data: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" . )) }}
 spec:
 {{ toYaml .Values.repository.persistentVolume.spec | nindent 2 }}
 {{- end -}}

--- a/charts/mirrorbits-lite/templates/persistentVolumeClaim.yaml
+++ b/charts/mirrorbits-lite/templates/persistentVolumeClaim.yaml
@@ -1,9 +1,9 @@
-{{ if $.Values.repository.persistentVolumeClaim.enabled -}}
+{{ if and .Values.repository.persistentVolumeClaim.enabled (not (dig "global" "ingress" "enabled" false .Values.AsMap)) -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $.Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .))  }}
+  name: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .))  }}
 spec:
-{{ toYaml $.Values.repository.persistentVolumeClaim.spec | nindent 2 }}
+{{ toYaml .Values.repository.persistentVolumeClaim.spec | nindent 2 }}
 {{- end -}}

--- a/charts/mirrorbits-lite/tests/defaults_test.yaml
+++ b/charts/mirrorbits-lite/tests/defaults_test.yaml
@@ -4,6 +4,9 @@ templates:
   - ingress.yaml
   - secret.yaml # Direct dependency of deployment(.*).yaml
   - service.yaml
+  - persistentVolume.yaml
+  - persistentVolumeClaim.yaml
+  - tests/mock_parent_helpers.tpl
 tests:
   - it: should not create any ingress by default
     template: ingress.yaml
@@ -39,3 +42,26 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
           value: /var/log/mirrorbits
+      # Data Volume is an emptyDir by default
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: data
+      - equal:
+          path: spec.template.spec.volumes[3].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /srv/repo
+  - it: should not define any persistent volume
+    template: persistentVolume.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not define any PV claim
+    template: persistentVolumeClaim.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/mirrorbits-lite/tests/parent_values_test.yaml
+++ b/charts/mirrorbits-lite/tests/parent_values_test.yaml
@@ -1,18 +1,18 @@
-suite: Tests with custom values
+suite: Tests with values from parent (umbrella ingress and umbrella PVC)
 templates:
   - deployment.yaml
   - ingress.yaml
   - secret.yaml # Direct dependency of deployment(.*).yaml
-  - service.yaml
   - persistentVolume.yaml
   - persistentVolumeClaim.yaml
-  - tests/mock_parent_helpers.tpl
 set:
-  image:
-    pullPolicy: Always
-  geoipupdate:
-    account_id: my-account-id
-    license_key: my-license-key
+  # Mock chart parent inherited global values passed to subcharts
+  global:
+    storage:
+      enabled: true
+    ingress:
+      enabled: true
+  # Try to specify a ingress which must be ignored (parent prevails)
   ingress:
     enabled: true
     hosts:
@@ -20,10 +20,7 @@ set:
         paths:
         - path: /
           pathType: IfNotPresent
-  logs:
-    volume:
-      persistentVolumeClaim:
-        claimName: foobar
+  # Try to specify a PV which must be ignored (parent prevails)
   repository:
     name: mirrorbits-binary
     persistentVolumeClaim:
@@ -58,21 +55,6 @@ set:
         mountOptions:
           - dir_mode=0755
 tests:
-  - it: Should set the correct service selector labels when a fullNameOverride is specified
-    template: service.yaml
-    set:
-      fullNameOverride: "my-fullNameOverride"
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Service
-      - equal:
-          path: spec.selector["app.kubernetes.io/name"]
-          value: "mirrorbits-lite"
-      - equal:
-          path: spec.selector["app.kubernetes.io/instance"]
-          value: "RELEASE-NAME"
   - it: should define a customized "mirrorbits-lite" deployment
     template: deployment.yaml
     asserts:
@@ -80,56 +62,31 @@ tests:
           count: 1
       - isKind:
           of: Deployment
-      - equal:
-          path: spec.template.spec.containers[*].imagePullPolicy
-          value: Always
-      # Log volumes is a custom PVC
-      - equal:
-          path: spec.template.spec.volumes[2].name
-          value: logs
-      - equal:
-          path: spec.template.spec.volumes[2].persistentVolumeClaim.claimName
-          value: foobar
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
-          value: logs
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
-          value: /var/log/mirrorbits
-      # Data Volume
+      # Data Volume (references a claim from parent chart)
       - equal:
           path: spec.template.spec.volumes[3].name
           value: data
       - equal:
           path: spec.template.spec.volumes[3].persistentVolumeClaim.claimName
-          value: mirrorbits-binary
+          value: parent-chart-shared-data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].name
           value: data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].mountPath
           value: /srv/repo
-  - it: should create ingress with pathType set to the specified custom value by default
+  - it: should not create any ingress
     template: ingress.yaml
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - equal:
-          path: spec.rules[0].http.paths[0].pathType
-          value: "IfNotPresent"
-  - it: should define a customized "mirrorbits-lite" persistent volume
+          count: 0
+  - it: should not define any persistent volume
     template: persistentVolume.yaml
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
-          of: PersistentVolume
-  - it: should define a customized "mirrorbits-lite" PV claim
+          count: 0
+  - it: should not define any PV claim
     template: persistentVolumeClaim.yaml
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
-          of: PersistentVolumeClaim
+          count: 0


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR is an extract of https://github.com/jenkins-infra/helm-charts/pull/813 scoped to only `mirrorbits-lite`


chore(mirrorbits-lite) increase unit test coverage to PV and PVC with their volumeMounts