### PR TITLE
fix(artifact-caching-proxy) set defaults on PDB

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.15.0
+version: 0.15.1

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -51,19 +51,34 @@ tests:
           path: metadata.annotations
           value:
             a-custom/annotation: "hello world"
-
-  - it: should ensure the pdb has correct spec
+  - it: should create a PDB with defaults when multiple replicas are set
+    template: pdb.yaml
+    set:
+      replicaCount: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels['app.kubernetes.io/name']
+          value: "artifact-caching-proxy"
+  - it: should create a PDB with the custom setup when custom values are set
     template: pdb.yaml
     set:
       replicaCount: 2
       poddisruptionbudget.minAvailable: 2
-      poddisruptionbudget.maxUnavailable: 1
+      poddisruptionbudget.maxUnavailable: 3
     asserts:
       - isKind:
           of: PodDisruptionBudget
       - equal:
           path: spec.minAvailable
           value: 2
+      - equal:
+          path: spec.maxUnavailable
+          value: 3
       - equal:
           path: spec.selector.matchLabels['app.kubernetes.io/name']
           value: "artifact-caching-proxy"

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -89,3 +89,5 @@ proxy:
   # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_bypass
   proxyBypass:
     enabled: false
+poddisruptionbudget:
+  minAvailable: 1


### PR DESCRIPTION
This PR fixes the error seen in https://github.com/jenkins-infra/kubernetes-management/pull/4460#pullrequestreview-1649313575 

```
[ERROR] templates/: template: artifact-caching-proxy/templates/pdb.yaml:9:18: executing "artifact-caching-proxy/templates/pdb.yaml" at <.Values.poddisruptionbudget.minAvailable>: nil pointer evaluating interface {}.minAvailable
```

💡Notes:

- Unit test added to cover the case when a PDB is created because multiple replicas are set up but with its default setup. This unit tests returns the error above with the version `0.15.0` of this chart
- Unit test added to verify the coverage of custom value `maxUnavailable`