### PR TITLE
fixup(httpd & mirrorbits-lite) remove all mocks from packaged chart

### DIFF
--- a/charts/httpd/.helmignore
+++ b/charts/httpd/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests/

--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,4 +1,8 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.2.0
+version: 0.2.1
+appVersion: v2.4
+maintainers:
+- email: jenkins-infra-team@googlegroups.com
+  name: jenkins-infra-team

--- a/charts/httpd/templates/_helpers.tpl
+++ b/charts/httpd/templates/_helpers.tpl
@@ -49,14 +49,14 @@ Data directory volume definition. Might be defined from parent chart templates o
 based on the presence of the global value provided by the parent chart.
 */}}
 {{- define "httpd.html-volume" -}}
-{{- if (dig "global" "storage" "enabled" false .Values.AsMap) -}}
+{{- if and (dig "global" "storage" "enabled" false .Values.AsMap) .Values.global.storage.claimNameTpl -}}
 persistentVolumeClaim:
-  claimName: {{ include "mirrorbits-parent.pvc-name" . }}
-{{- else }}
-  {{- if or .Values.repository.persistentVolumeClaim.enabled .Values.repository.reuseExistingPersistentVolumeClaim }}
+  claimName: {{ printf "%s" (tpl .Values.global.storage.claimNameTpl $) | trim | trunc 63 }}
+{{- else -}}
+  {{- if or .Values.repository.persistentVolumeClaim.enabled .Values.repository.reuseExistingPersistentVolumeClaim -}}
 persistentVolumeClaim:
-  claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "httpd.fullname" .)) }}
-  {{- else }}
+  claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "httpd.fullname" .)) -}}
+  {{- else -}}
 emptyDir: {}
   {{- end -}}
 {{- end -}}

--- a/charts/httpd/templates/mocks/_helpers.tpl
+++ b/charts/httpd/templates/mocks/_helpers.tpl
@@ -1,3 +1,0 @@
-{{- define "mirrorbits-parent.pvc-name" -}}
-parent-chart-shared-data
-{{- end -}}

--- a/charts/httpd/tests/parent_values_test.yaml
+++ b/charts/httpd/tests/parent_values_test.yaml
@@ -10,6 +10,7 @@ set:
   global:
     storage:
       enabled: true
+      claimNameTpl: '{{ default "parent-chart-shared-data" }}'
     ingress:
       enabled: true
   # Try to specify a ingress which must be ignored (parent prevails)

--- a/charts/mirrorbits-lite/.helmignore
+++ b/charts/mirrorbits-lite/.helmignore
@@ -20,4 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
-tests/*
+tests/

--- a/charts/mirrorbits-lite/Chart.yaml
+++ b/charts/mirrorbits-lite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits lite helm chart for Kubernetes
 name: mirrorbits-lite
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits-lite/templates/_helpers.tpl
+++ b/charts/mirrorbits-lite/templates/_helpers.tpl
@@ -49,14 +49,14 @@ Data directory volume definition. Might be defined from parent chart templates o
 based on the presence of the global value provided by the parent chart.
 */}}
 {{- define "mirrorbits-lite.data-volume" -}}
-{{- if (dig "global" "storage" "enabled" false .Values.AsMap) -}}
+{{- if and (dig "global" "storage" "enabled" false .Values.AsMap) .Values.global.storage.claimNameTpl -}}
 persistentVolumeClaim:
-  claimName: {{ include "mirrorbits-parent.pvc-name" . }}
-{{- else }}
-  {{- if .Values.repository.persistentVolumeClaim.enabled }}
+  claimName: {{ printf "%s" (tpl .Values.global.storage.claimNameTpl $) | trim | trunc 63 }}
+{{- else -}}
+  {{- if .Values.repository.persistentVolumeClaim.enabled -}}
 persistentVolumeClaim:
   claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits-lite.fullname" .)) }}
-  {{- else }}
+  {{- else -}}
 emptyDir: {}
   {{- end -}}
 {{- end -}}

--- a/charts/mirrorbits-lite/templates/mocks/_helpers.tpl
+++ b/charts/mirrorbits-lite/templates/mocks/_helpers.tpl
@@ -1,3 +1,0 @@
-{{- define "mirrorbits-parent.pvc-name" -}}
-parent-chart-shared-data
-{{- end -}}

--- a/charts/mirrorbits-lite/tests/parent_values_test.yaml
+++ b/charts/mirrorbits-lite/tests/parent_values_test.yaml
@@ -10,6 +10,7 @@ set:
   global:
     storage:
       enabled: true
+      claimNameTpl: '{{ default "parent-chart-shared-data" }}'
     ingress:
       enabled: true
   # Try to specify a ingress which must be ignored (parent prevails)


### PR DESCRIPTION
This PR is a fixup of #817 and #818.

These past PRs did not break the current `update-jenkins-io` *but* the new feature to use global PVC/ingress from parent chart had some hiccups.

Namely, the mocks used for unit tests are packaged with the subchart and adding the pattern `*mock*` to the [`.helmignore`](https://helm.sh/docs/chart_template_guide/helm_ignore_file/) results in unit test failing because, with the current 0.3.5 version of unit tests, it does not access files ignores by the`.helmignore`.

The result is, when trying on real life, the mocked templates takes over the expected template from the parent chart leading to unexpected results.

The proposed solution (2 commits, 1 per chart) proposes to use a combination of:

- An idea by @lemeurherve around passing the PVC name through the global value from parent chart to subchart. I've initially denied this proposal as using a static value forbids multiple installations of the chart (or at least makes it tedious to maintain).
- BUT I found this issue: https://github.com/helm-unittest/helm-unittest/issues/171 about helm library chart tests which is the same kind of problem (mocking templates between charts). The proposed (hackish) solution uses the `tpl` engine to pass the template to underlying subcharts.

Tested in "production" with the helmfile diff and https://github.com/helm/helm/issues/9987 and the results looks really well.

*However* I'm opening this in draft until we evaluate the risks of this solution as it could be (ab)used to extract credentials of the PVCs with helmfile diff (as this is a user input).
