### PR TITLE
feat(rsyncd) allow overriding PV(C)s based on global value from parent chart

### DIFF
--- a/charts/rsyncd/.helmignore
+++ b/charts/rsyncd/.helmignore
@@ -14,9 +14,11 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project
 .idea/
 *.tmproj
 .vscode/
+tests/

--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 1.3.2
+version: 1.4.0
+maintainers:
+- email: jenkins-infra-team@googlegroups.com
+  name: jenkins-infra-team

--- a/charts/rsyncd/templates/_helpers.tpl
+++ b/charts/rsyncd/templates/_helpers.tpl
@@ -44,7 +44,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
-
 {{/*
 Data directory volume definition. Might be defined from parent chart templates or autonomously
 based on the presence of the global value provided by the parent chart.

--- a/charts/rsyncd/templates/_helpers.tpl
+++ b/charts/rsyncd/templates/_helpers.tpl
@@ -43,3 +43,23 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+
+{{/*
+Data directory volume definition. Might be defined from parent chart templates or autonomously
+based on the presence of the global value provided by the parent chart.
+Expected argument: dict{
+  "currentRsyncComponent": <string>,
+  "rootContext": { },
+}
+*/}}
+{{- define "rsync.datadir-volumedef" -}}
+{{- if .currentRsyncComponent.volumeTpl -}}
+persistentVolumeClaim:
+  claimName: {{ printf "%s" (tpl .currentRsyncComponent.volumeTpl .rootContext) | trim | trunc 63 -}}
+{{- else if .currentRsyncComponent.volume -}}
+  {{- toYaml .currentRsyncComponent.volume -}}
+{{- else -}}
+emptyDir: {}
+{{- end -}}
+{{- end -}}

--- a/charts/rsyncd/templates/_helpers.tpl
+++ b/charts/rsyncd/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Expected argument: dict{
   "rootContext": { },
 }
 */}}
-{{- define "rsync.datadir-volumedef" -}}
+{{- define "rsync.datadir-volumedefinition" -}}
 {{- if .currentRsyncComponent.volumeTpl -}}
 persistentVolumeClaim:
   claimName: {{ printf "%s" (tpl .currentRsyncComponent.volumeTpl .rootContext) | trim | trunc 63 -}}

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -94,9 +94,5 @@ spec:
             sizeLimit: 32Mi
         {{- range .Values.configuration.components }}
         - name: datadir-{{ .name }}
-          {{- if .volume }}
-            {{- toYaml .volume  | nindent 10 }}
-          {{- else }}
-          emptyDir:
-          {{ end }}
+          {{- include "rsync.datadir-volumedef" (dict "currentRsyncComponent" . "rootContext" $) | nindent 10 }}
         {{- end }}

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -94,5 +94,5 @@ spec:
             sizeLimit: 32Mi
         {{- range .Values.configuration.components }}
         - name: datadir-{{ .name }}
-          {{- include "rsync.datadir-volumedef" (dict "currentRsyncComponent" . "rootContext" $) | nindent 10 }}
+          {{- include "rsync.datadir-volumedefinition" (dict "currentRsyncComponent" . "rootContext" $) | nindent 10 }}
         {{- end }}

--- a/charts/rsyncd/tests/parent_values_test.yaml
+++ b/charts/rsyncd/tests/parent_values_test.yaml
@@ -66,7 +66,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[3].subPath
           value: run
       # Custom Rsyncd components
-      ## jenkins (1 configmap volume mount + 1 data volume and 1 volumemount for data dir)
+      ## jenkins (1 configmap volume mount + 1 data volume and 1 volume mount for data directory)
       - equal:
           path: spec.template.spec.volumes[2].name
           value: datadir-jenkins
@@ -96,7 +96,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[5].readOnly
           value: true
-      ## hudson (1 configmap volume mount + 1 data volume and 1 volumemount for data dir)
+      ## hudson (1 configmap volume mount + 1 data volume and 1 volume mount for data directory)
       - equal:
           path: spec.template.spec.volumes[3].name
           value: datadir-hudson

--- a/charts/rsyncd/tests/parent_values_test.yaml
+++ b/charts/rsyncd/tests/parent_values_test.yaml
@@ -1,0 +1,147 @@
+suite: Tests with parent values
+# Custom values used to test all suites from this file
+set:
+  global:
+    storage:
+      enabled: true
+  configuration:
+    components:
+      - name: jenkins
+        path: /rsyncd/data/jenkins
+        comment: "Jenkins Read-Only Mirror"
+        volumeTpl: '{{ default "parent-chart-shared-data" }}'
+      - name: hudson
+        path: /tmp/hudson
+        comment: "Hudson Read-Only Mirror"
+        volume:
+          persistentVolumeClaim:
+            claimName: another-vol
+tests:
+  - it: should define a customized "rsyncd" deployment
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      # Custom rsyncd.inc configuration overlay is mounted from the rsyncd-conf configmap
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: rsyncd-conf
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: RELEASE-NAME-rsyncd-conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: rsyncd-conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+          value: rsyncd.inc
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /etc/rsyncd.d/rsyncd.inc
+      # TempFS volumes
+      -  equal:
+          path: spec.template.spec.volumes[1].name
+          value: ramfs
+      -  equal:
+          path: spec.template.spec.volumes[1].emptyDir.medium
+          value: Memory
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].name
+          value: ramfs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /tmp
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].subPath
+          value: tmp
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: ramfs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /rsync/run
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].subPath
+          value: run
+      # Custom Rsyncd components
+      ## jenkins (1 configmap volume mount + 1 data volume and 1 volumemount for data dir)
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: datadir-jenkins
+      - equal:
+          path: spec.template.spec.volumes[2].persistentVolumeClaim.claimName
+          value: parent-chart-shared-data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: rsyncd-conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
+          value: /etc/rsyncd.d/jenkins.conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].subPath
+          value: jenkins.conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].readOnly
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].name
+          value: datadir-jenkins
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].mountPath
+          value: /rsyncd/data/jenkins
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[5].subPath
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[5].readOnly
+          value: true
+      ## hudson (1 configmap volume mount + 1 data volume and 1 volumemount for data dir)
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: datadir-hudson
+      - equal:
+          path: spec.template.spec.volumes[3].persistentVolumeClaim.claimName
+          value: another-vol
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[6].name
+          value: rsyncd-conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[6].mountPath
+          value: /etc/rsyncd.d/hudson.conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[6].subPath
+          value: hudson.conf
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[6].readOnly
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[7].name
+          value: datadir-hudson
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[7].mountPath
+          value: /tmp/hudson
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[7].subPath
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[7].readOnly
+          value: true
+  - it: should create a custom rsyncd-conf config map
+    template: configmap.rsyncd-conf.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rsyncd-conf
+      - matchRegex:
+          path: data["jenkins.conf"]
+          pattern: "[jenkins]"
+      - matchRegex:
+          path: data["hudson.conf"]
+          pattern: "[hudson]"
+      - matchRegex:
+          path: data["hudson.conf"]
+          pattern: "path = /tmp/hudson"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

Same idea as #817 and #818 , this PR allows passing template in rsync component definitions, for dynamic evaluation of the PVC name.