### PR TITLE
fix(mirrorbit-lite) only create secrets when needed

### DIFF
--- a/charts/mirrorbits-lite/.helmignore
+++ b/charts/mirrorbits-lite/.helmignore
@@ -14,6 +14,7 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project

--- a/charts/mirrorbits-lite/Chart.yaml
+++ b/charts/mirrorbits-lite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits lite helm chart for Kubernetes
 name: mirrorbits-lite
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits-lite/templates/deployment.yaml
+++ b/charts/mirrorbits-lite/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "mirrorbits-lite.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
+        checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | trunc 63 }}
     spec:
       automountServiceAccountToken: false
     {{- with .Values.imagePullSecrets }}

--- a/charts/mirrorbits-lite/templates/secrets.yaml
+++ b/charts/mirrorbits-lite/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 data:
   mirrorbits.conf: {{ .Values.conf | b64enc }}
-
+{{- if and .Values.geoipupdate.account_id .Values.geoipupdate.license_key }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,8 +16,8 @@ type: Opaque
 data:
   GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geoipupdate.account_id | b64enc }}
   GEOIPUPDATE_LICENSE_KEY: {{ .Values.geoipupdate.license_key | b64enc }}
-
-{{ if .Values.repository.secrets.enabled -}}
+{{- end }}
+{{- if and .Values.repository.secrets.enabled (not (dig "global" "storage" "enabled" false .Values.AsMap)) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/mirrorbits-lite/tests/custom_values_test.yaml
+++ b/charts/mirrorbits-lite/tests/custom_values_test.yaml
@@ -2,7 +2,7 @@ suite: Tests with custom values
 templates:
   - deployment.yaml
   - ingress.yaml
-  - secret.yaml # Direct dependency of deployment.yaml
+  - secrets.yaml
   - service.yaml
   - pdb.yaml
   - persistentVolume.yaml
@@ -58,6 +58,11 @@ set:
             namespace: mirrorbits
         mountOptions:
           - dir_mode=0755
+    secrets:
+      enabled: true
+      data:
+        azurestorageaccountkey: 'SuperSecretKey!'
+        azurestorageaccountname: storage-account-in-az
 tests:
   - it: Should set the correct service selector labels when a fullNameOverride is specified
     template: service.yaml
@@ -170,3 +175,29 @@ tests:
       - equal:
           path: spec.selector.matchLabels['app.kubernetes.io/name']
           value: mirrorbits-lite
+  - it: should create all secrets
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-lite
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-lite-geoipupdate
+      - documentIndex: 2
+        isKind:
+          of: Secret
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-lite-binary

--- a/charts/mirrorbits-lite/tests/defaults_test.yaml
+++ b/charts/mirrorbits-lite/tests/defaults_test.yaml
@@ -73,7 +73,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should not create only create the mirrorbits conf secret by default
+  - it: should only create the mirrorbits conf secret by default
     template: secrets.yaml
     asserts:
       - hasDocuments:

--- a/charts/mirrorbits-lite/tests/defaults_test.yaml
+++ b/charts/mirrorbits-lite/tests/defaults_test.yaml
@@ -2,7 +2,7 @@ suite: default tests
 templates:
   - deployment.yaml
   - ingress.yaml
-  - secret.yaml # Direct dependency of deployment(.*).yaml
+  - secrets.yaml
   - service.yaml
   - pdb.yaml
   - persistentVolume.yaml
@@ -73,3 +73,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should not create only create the mirrorbits conf secret by default
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-lite

--- a/charts/mirrorbits-lite/tests/parent_values_test.yaml
+++ b/charts/mirrorbits-lite/tests/parent_values_test.yaml
@@ -2,7 +2,7 @@ suite: Tests with values from parent (umbrella ingress and umbrella PVC)
 templates:
   - deployment.yaml
   - ingress.yaml
-  - secret.yaml # Direct dependency of deployment.yaml
+  - secrets.yaml
   - persistentVolume.yaml
   - persistentVolumeClaim.yaml
 set:
@@ -55,6 +55,11 @@ set:
             namespace: mirrorbits
         mountOptions:
           - dir_mode=0755
+    secrets:
+      enabled: true
+      data:
+        azurestorageaccountkey: 'SuperSecretKey!'
+        azurestorageaccountname: storage-account-in-az
 tests:
   - it: should define a customized "mirrorbits-lite" deployment
     template: deployment.yaml
@@ -91,3 +96,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should not create only create the mirrorbits conf secret (global storage overrides local PVC secrets)
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-lite

--- a/charts/mirrorbits-lite/tests/parent_values_test.yaml
+++ b/charts/mirrorbits-lite/tests/parent_values_test.yaml
@@ -96,7 +96,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should not create only create the mirrorbits conf secret (global storage overrides local PVC secrets)
+  - it: should only create the mirrorbits conf secret (global storage overrides local PVC secrets)
     template: secrets.yaml
     asserts:
       - hasDocuments:


### PR DESCRIPTION
While working on the parent chart for https://github.com/jenkins-infra/helpdesk/issues/2649, caught this tiny bug in the helm chart where secrets where created even if values are not provided.

This PR fixes the bug by adding conditions to create the secrets (and tests).