### PR TITLE
feat(plugin-site-frontend): add PDB and unittest

### DIFF
--- a/charts/plugin-site/Chart.yaml
+++ b/charts/plugin-site/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - name: timja
 - name: halkeye
 name: plugin-site
-version: 0.2.0
+version: 0.3.0

--- a/charts/plugin-site/templates/_helpers.tpl
+++ b/charts/plugin-site/templates/_helpers.tpl
@@ -32,12 +32,27 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Selector labels frontend
+*/}}
+{{- define "plugin-site-frontend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "plugin-site.name" . }}-frontend
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "plugin-site.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "plugin-site.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "plugin-site.labels" -}}
-app.kubernetes.io/name: {{ include "plugin-site.name" . }}
+{{ include "plugin-site.selectorLabels" . }}
 helm.sh/chart: {{ include "plugin-site.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/charts/plugin-site/templates/deployment-frontend.yaml
+++ b/charts/plugin-site/templates/deployment-frontend.yaml
@@ -67,7 +67,11 @@ spec:
     {{- end }}
       volumes:
         - name: html
+        {{- if .Values.htmlVolume }}
 {{ toYaml .Values.htmlVolume | indent 10 }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "plugin-site.fullname" . }}-nginx

--- a/charts/plugin-site/templates/pdb-frontend.yaml
+++ b/charts/plugin-site/templates/pdb-frontend.yaml
@@ -1,0 +1,18 @@
+{{- if (gt (int .Values.frontend.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "plugin-site.fullname" . }}-frontend
+  labels:
+    {{- include "plugin-site.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.frontend.poddisruptionbudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.frontend.poddisruptionbudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "plugin-site-frontend.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/plugin-site/tests/custom_values_test.yaml
+++ b/charts/plugin-site/tests/custom_values_test.yaml
@@ -1,0 +1,72 @@
+suite: Test with custom values
+templates:
+  - deployment-frontend.yaml
+  - ingress.yaml
+  - pdb-frontend.yaml
+  - nginx-configmap.yaml # Direct dependency of deployment.yaml
+tests:
+  - it: should create an ingress when ingress.enabled is true
+    set:
+      ingress:
+        enabled: true
+    template: ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: should mount the html volume when htmlVolume is set
+    template: deployment-frontend.yaml
+    set:
+      htmlVolume:
+        hostPath: /host
+      frontend:
+        resources:
+          limits:
+            cpu: 300ms
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: html
+      - equal:
+          path: spec.template.spec.volumes[0].hostPath
+          value: /host
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 300ms
+  - it: should create a PDB with defaults when multiple replicas are set
+    template: pdb-frontend.yaml
+    set:
+      frontend:
+        replicaCount: 4
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels['app.kubernetes.io/name']
+          value: "plugin-site-frontend"
+  - it: should ensure the pdb has correct spec
+    template: pdb-frontend.yaml
+    set:
+      frontend:
+        replicaCount: 3
+        poddisruptionbudget:
+          minAvailable: 2
+          maxUnavailable: 3
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - equal:
+          path: spec.maxUnavailable
+          value: 3
+      - equal:
+          path: spec.selector.matchLabels['app.kubernetes.io/name']
+          value: "plugin-site-frontend"

--- a/charts/plugin-site/tests/custom_values_test.yaml
+++ b/charts/plugin-site/tests/custom_values_test.yaml
@@ -36,21 +36,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 300ms
-  - it: should create a PDB with defaults when multiple replicas are set
-    template: pdb-frontend.yaml
-    set:
-      frontend:
-        replicaCount: 4
-    asserts:
-      - isKind:
-          of: PodDisruptionBudget
-      - equal:
-          path: spec.minAvailable
-          value: 1
-      - equal:
-          path: spec.selector.matchLabels['app.kubernetes.io/name']
-          value: "plugin-site-frontend"
-  - it: should ensure the pdb has correct spec
+  - it: should create a customized PDB with the provided spec
     template: pdb-frontend.yaml
     set:
       frontend:

--- a/charts/plugin-site/tests/defaults_values_test.yaml
+++ b/charts/plugin-site/tests/defaults_values_test.yaml
@@ -35,8 +35,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 100m
-  - it: should generate a pdb with default values
+  - it: should create a pdb with default values as the frontend service is replicated to 2 by default
     template: pdb-frontend.yaml
     asserts:
       - hasDocuments:
           count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels['app.kubernetes.io/name']
+          value: "plugin-site-frontend"

--- a/charts/plugin-site/tests/defaults_values_test.yaml
+++ b/charts/plugin-site/tests/defaults_values_test.yaml
@@ -1,0 +1,42 @@
+suite: Test with default values
+templates:
+  - deployment-frontend.yaml
+  - ingress.yaml
+  - pdb-frontend.yaml
+  - nginx-configmap.yaml
+tests:
+  - it: should  not create an ingress by default
+    template: ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should define the default deployment with default imagePullPolicy
+    template: deployment-frontend.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: plugin-site
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: html
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+  - it: should generate a pdb with default values
+    template: pdb-frontend.yaml
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -30,6 +30,8 @@ frontend:
     requests:
       cpu: 100m
       memory: 32Mi
+  poddisruptionbudget:
+    minAvailable: 1
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3719

```
plugin-site, plugin-site-frontend, PodDisruptionBudget (policy) has been added:
- 
+ # Source: plugin-site/templates/pdb-frontend.yaml
+ apiVersion: policy/v1
+ kind: PodDisruptionBudget
+ metadata:
+   name: plugin-site-frontend
+   labels:
+     app.kubernetes.io/name: plugin-site
+     app.kubernetes.io/instance: plugin-site
+     helm.sh/chart: plugin-site-0.3.0
+     app.kubernetes.io/version: "1.0"
+     app.kubernetes.io/managed-by: Helm
+     jenkins.io/maintainer: timja
+ spec:
+   minAvailable: 1
+   selector:
+     matchLabels:
+       app.kubernetes.io/name: plugin-site-frontend
+       app.kubernetes.io/instance: plugin-site
```