### PR TITLE
fix(plugin-site) bump Docker image to switch JDK8 to Temurin `1.8.0_382` (and support of cgroups v2)

### DIFF
--- a/charts/plugin-site/Chart.yaml
+++ b/charts/plugin-site/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - name: timja
 - name: halkeye
 name: plugin-site
-version: 0.4.0
+version: 0.4.1

--- a/charts/plugin-site/values.yaml
+++ b/charts/plugin-site/values.yaml
@@ -6,7 +6,7 @@ backend:
   replicaCount: 2
   image:
     repository: jenkinsciinfra/plugin-site-api
-    tag: 294-5389ef
+    tag: 295-d7103b
     pullPolicy: IfNotPresent
   port: 8080
   resources:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3774, this PR bumps the container image to a new version with a JDK Temurin version `1.8.0_382`.

The goal is to only deploy the JDK change to support cgroups v2 in production.


We did a quick test on a Docker Desktop macOS machine (which uses cgroupsv2 in the LinuxVM) with success:

- The Docker Desktop VM is set up with 16Gb of memory
- The default heap size is 25% of what is perceived by the JVM as "the amount of memory available to use"

Before (current production image) states ~4Gb of Heap despite the specified memory limit at 1G:

```bash
$ docker run --entrypoint=bash --platform=linux/amd64 --memory=1G jenkinsciinfra/plugin-site-api:294-5389ef -c 'java -XX:+PrintFlagsFinal -version | grep HeapSize'
openjdk version "1.8.0_322"
OpenJDK Runtime Environment (build 1.8.0_322-b06)
OpenJDK 64-Bit Server VM (build 25.322-b06, mixed mode)
    uintx ErgoHeapSizeLimit                         = 0                                   {product}
    uintx HeapSizePerGCThread                       = 87241520                            {product}
    uintx InitialHeapSize                          := 262144000                           {product}
    uintx LargePageHeapSizeThreshold                = 134217728                           {product}
    uintx MaxHeapSize                              := 4192206848                          {product}
```

After (new image with new Temurin JDK8) shows ~250 Mb of heap size ✅ 

```bash
$ docker run --entrypoint=bash --platform=linux/amd64 --memory=1G jenkinsciinfra/plugin-site-api:295-d7103b -c 'java -XX:+PrintFlagsFinal -version | grep HeapSize'
openjdk version "1.8.0_382"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_382-b05)
OpenJDK 64-Bit Server VM (Temurin)(build 25.382-b05, mixed mode)
    uintx ErgoHeapSizeLimit                         = 0                                   {product}
    uintx HeapSizePerGCThread                       = 87241520                            {product}
    uintx InitialHeapSize                          := 16777216                            {product}
    uintx LargePageHeapSizeThreshold                = 134217728                           {product}
    uintx MaxHeapSize                              := 268435456                           {product}
```