### PR TITLE
Fix `rating` chart render issue and add unit tests

### DIFF
--- a/charts/rating/Chart.yaml
+++ b/charts/rating/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: rating
 type: application
-version: 0.3.5
+version: 0.3.6

--- a/charts/rating/templates/deployment.yaml
+++ b/charts/rating/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled -}}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /rate/result.php

--- a/charts/rating/tests/defaults_test.yaml
+++ b/charts/rating/tests/defaults_test.yaml
@@ -1,0 +1,13 @@
+suite: test default behavior of deployment.yaml with default values
+templates:
+  - deployment.yaml
+  - secret.yaml
+tests:
+  - it: should render with default values without error
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rating


### PR DESCRIPTION
### Detail
 - Fix #661
 - `{{- if ~~ -}}` will be render inappropriately (ref: https://helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace)
   - remove trailing `-`, so it renders well.
 - Add simple unit test to ensure rendering.

### Testing
 - original `deployment.yaml`
   - ![image](https://github.com/jenkins-infra/helm-charts/assets/16630665/97c45092-4262-416e-8102-d72ba398c875)
 - fixed version
   - ![image](https://github.com/jenkins-infra/helm-charts/assets/16630665/0e46eafc-ae64-47fd-8bb9-21f353c0839c)