### PR TITLE
fix(uplink): use tag instead of sha256 for the Docker image

### DIFF
--- a/charts/uplink/Chart.yaml
+++ b/charts/uplink/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for uplink.jenkins.io
 name: uplink
-version: 0.3.2
+version: 0.3.3
 maintainers:
   - name: olblak
   - name: dduportal

--- a/charts/uplink/Chart.yaml
+++ b/charts/uplink/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for uplink.jenkins.io
 name: uplink
-version: 0.3.1
+version: 0.3.2
 maintainers:
   - name: olblak
   - name: dduportal

--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: jenkinsciinfra/uplink@sha256
-  tag: e57f1ee08d37c985388ebc87aafd3e7a73ad0a1a950abc1d2eb00c093eb3e76b
+  tag: 0.0.2@sha256:e57f1ee08d37c985388ebc87aafd3e7a73ad0a1a950abc1d2eb00c093eb3e76b
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: jenkinsciinfra/uplink@sha256
-  tag: 0.0.2@sha256:e57f1ee08d37c985388ebc87aafd3e7a73ad0a1a950abc1d2eb00c093eb3e76b
+  tag: 0.0.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: jenkinsciinfra/uplink
-  tag: 0.0.2
+  tag: 0.1.0
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/uplink/values.yaml
+++ b/charts/uplink/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  repository: jenkinsciinfra/uplink@sha256
+  repository: jenkinsciinfra/uplink
   tag: 0.0.2
   pullPolicy: IfNotPresent
 imagePullSecrets: []

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -20,8 +20,6 @@ sources:
       image: "jenkinsciinfra/uplink"
       tag: "latest"
       architecture: "amd64"
-    transformers:
-      - trimprefix: '@sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 

--- a/updatecli/updatecli.d/uplink.yaml
+++ b/updatecli/updatecli.d/uplink.yaml
@@ -20,7 +20,6 @@ sources:
       image: "jenkinsciinfra/uplink"
       tag: "latest"
       architecture: "amd64"
-      hidetag: true
     transformers:
       - trimprefix: '@sha256:'
 


### PR DESCRIPTION
Using a sha256 blocks the deployment of the arm64 image by the chart, thus this PR switch to the named tag instead of the sha256 in the values.

Related:
- https://github.com/jenkins-infra/kubernetes-management/pull/4610

Note: the image specs override in kubernetes-management has been removed:
- https://github.com/jenkins-infra/kubernetes-management/pull/4607