### PR TITLE
fix(mirrorbit-parent) add missing permission to allow exec on a pod

### DIFF
--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 1.1.1
+version: 1.1.2
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/mirrorbits-parent/templates/serviceaccount.yaml
+++ b/charts/mirrorbits-parent/templates/serviceaccount.yaml
@@ -12,6 +12,9 @@ metadata:
   name: {{ template "mirrorbits-parent.serviceAccountName" . }}-role
 rules:
 - apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create","delete","get","list","patch","update","watch"]
 ---

--- a/charts/mirrorbits-parent/tests/custom_values_serviceaccount_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_serviceaccount_test.yaml
@@ -31,14 +31,22 @@ tests:
       - documentIndex: 1
         lengthEqual:
           path: rules
-          count: 1
+          count: 2
       - documentIndex: 1
         lengthEqual:
           path: rules[0].verbs
+          count: 1
+      - documentIndex: 1
+        lengthEqual:
+          path: rules[1].verbs
           count: 7
       - documentIndex: 1
         equal:
           path: rules[0].resources[0]
+          value: pods
+      - documentIndex: 1
+        equal:
+          path: rules[1].resources[0]
           value: pods/exec
       - isKind:
           of: RoleBinding


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1787324647

Tested on a k3d local cluster: no need for addition permissions other than this one