### PR TITLE
chore(updatecli): ensure every arm64 migrated service manifest is checking for arm64 image too

### DIFF
--- a/updatecli/updatecli.d/httpd.yaml
+++ b/updatecli/updatecli.d/httpd.yaml
@@ -19,7 +19,10 @@ sources:
     spec:
       image: "httpd"
       tag: "2.4"
-      architecture: "amd64"
+      ## Tag from source
+      architectures:
+        - amd64
+        - arm64
 
 # no condition to test httpd docker image availability as we're using a digest from docker hub
 

--- a/updatecli/updatecli.d/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/incrementals-publisher.yaml
@@ -29,7 +29,10 @@ conditions:
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/incrementals-publisher"
-      architecture: "amd64"
+      ## Tag from source
+      architectures:
+        - amd64
+        - arm64
 
 targets:
   updateChart:

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -38,8 +38,10 @@ conditions:
     sourceid: latestRelease
     spec:
       image: "nginx"
-      architecture: amd64
-      # tag comes from the source input value
+      ## Tag from source
+      architectures:
+        - amd64
+        - arm64
 
 targets:
   updateJavadocChart:

--- a/updatecli/updatecli.d/rating.yaml
+++ b/updatecli/updatecli.d/rating.yaml
@@ -30,7 +30,10 @@ conditions:
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/rating"
-      architecture: "amd64"
+      ## Tag from source
+      architectures:
+        - amd64
+        - arm64
 
 targets:
   updateChart:

--- a/updatecli/updatecli.d/wiki.yaml
+++ b/updatecli/updatecli.d/wiki.yaml
@@ -29,6 +29,7 @@ conditions:
     sourceid: latestRelease
     spec:
       image: "jenkinsciinfra/wiki"
+      ## Tag from source
       architectures:
         - amd64
         - arm64


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3619