### PR TITLE
chore(GHA): remove `on.*.paths` from required workflows

### DIFF
--- a/.github/workflows/check-chart-versions-bump.yml
+++ b/.github/workflows/check-chart-versions-bump.yml
@@ -1,8 +1,6 @@
 name: Check chart version bump
 on:
   pull_request:
-    paths:
-      - 'charts/**'
 jobs:
   check_version_bump_on_modified_charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'charts/**'
   pull_request:
-    paths:
-      - 'charts/**'
   workflow_dispatch:
 env:
   UNITTEST_VERSION: v0.3.5


### PR DESCRIPTION
This PR removes the `on.*.paths` from workflows set as required status checks in branch protections.

These workflows already check if there are charts modified, and currently this prevents merging pull requests without bypassing branch protections if they don't contain changes to the `charts` folder.

#### Example of blocked PR where we can notice required status checks don't start:
- https://github.com/jenkins-infra/helm-charts/pull/912

<img width="800" alt="image" src="https://github.com/jenkins-infra/helm-charts/assets/91831478/98801d91-c520-4a6c-beac-5eb37783deac">

#### Comparison with this PR:
<img width="804" alt="image" src="https://github.com/jenkins-infra/helm-charts/assets/91831478/8a60d301-d5b7-4925-b971-52e28f20d908">
