### PR TITLE
fix(httpd): don't include sha256 in `image.tag` value

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.2.3
+version: 0.2.4
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: httpd
-  tag: 2.4@sha256:2f1ec45327a35711f293cf543c2e0efadfd44bc71e8081dcd76a558b99778005
+  tag: 2.4.58
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/httpredirector/Chart.yaml
+++ b/charts/httpredirector/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2

--- a/charts/httpredirector/Chart.yaml
+++ b/charts/httpredirector/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.1

--- a/updatecli/updatecli.d/httpd.yaml
+++ b/updatecli/updatecli.d/httpd.yaml
@@ -13,23 +13,30 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  latestHttpdRelease:
-    name: Get latest digest of the Docker Image for httpd, in version 2.4
-    kind: dockerdigest
+  latestRelease:
+    kind: githubrelease
+    name: "Get latest apache/httpd release"
+    spec:
+      owner: "apache"
+      repository: "httpd"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkDockerImagePublished:
+    name: "Test httpd:<latest_version> docker image tag"
+    kind: dockerimage
     spec:
       image: "httpd"
-      tag: "2.4"
       ## Tag from source
       architectures:
         - amd64
         - arm64
 
-# no condition to test httpd docker image availability as we're using a digest from docker hub
-
 targets:
   updateHttpd:
     name: "Update httpd docker image version"
-    sourceid: latestHttpdRelease
+    sourceid: latestRelease
     kind: helmchart
     spec:
       name: charts/httpd
@@ -41,7 +48,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump `httpd` docker images and helm chart versions
+    title: Bump `httpd` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Using a sha256 blocks the deployment of the arm64 image by the chart, thus this PR removes the sha256 from the tag values.

Similar to:
- https://github.com/jenkins-infra/helm-charts/pull/903

Related:
- https://github.com/jenkins-infra/kubernetes-management/pull/4586

Closes #913 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3619