### PR TITLE
chore(updatecli): also target `httpd` image version without sha256 in `mirrorbits` chart

### DIFF
--- a/updatecli/updatecli.d/httpd.yaml
+++ b/updatecli/updatecli.d/httpd.yaml
@@ -35,12 +35,21 @@ conditions:
 
 targets:
   updateHttpd:
-    name: "Update httpd docker image version"
+    name: "Update httpd docker image version in httpd chart"
     sourceid: latestRelease
     kind: helmchart
     spec:
       name: charts/httpd
       key: $.image.tag
+      versionincrement: patch
+    scmid: default
+  updateHttpdInMirrorbits:
+    name: "Update httpd docker image version in mirrorbits chart"
+    sourceid: latestRelease
+    kind: helmchart
+    spec:
+      name: charts/mirrorbits
+      key: $.image.files.tag
       versionincrement: patch
     scmid: default
 


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/helm-charts/pull/915 for `mirrorbits` original chart, to allow its `httpd` "files" service to be deployed on arm64.

Related:
- https://github.com/jenkins-infra/kubernetes-management/pull/4586

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3619