### PR TITLE
feat(httpd) tailor configuration for Jenkins's mirrorbits usage

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.2.4
+version: 0.3.0
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -184,14 +184,14 @@ data:
     # in which case these default settings will be overridden for the
     # virtual host being defined.
     #
-    
+
     #
     # ServerAdmin: Your address, where problems with the server should be
     # e-mailed.  This address appears on some server-generated pages, such
     # as error documents.  e.g. admin@your-domain.com
     #
-    ServerAdmin me@olblak.com
-    
+    ServerAdmin jenkins-infra-team@googlegroups.com
+
     #
     # ServerName gives the name and port that the server uses to identify itself.
     # This can often be determined automatically, but we recommend you specify

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -4,10 +4,14 @@ metadata:
   name: {{ include "httpd.fullname" . }}
 data:
   httpd.conf: |
+    # Security
+    ServerTokens Prod
+    ServerSignature Off
+
     ServerRoot "/usr/local/apache2"
-    
+
     Listen 80
-    
+
     #
     # Dynamic Shared Object (DSO) Support
     #
@@ -138,10 +142,10 @@ data:
     #LoadModule info_module modules/mod_info.so
     #LoadModule suexec_module modules/mod_suexec.so
     <IfModule !mpm_prefork_module>
-    	#LoadModule cgid_module modules/mod_cgid.so
+      #LoadModule cgid_module modules/mod_cgid.so
     </IfModule>
     <IfModule mpm_prefork_module>
-    	#LoadModule cgi_module modules/mod_cgi.so
+      #LoadModule cgi_module modules/mod_cgi.so
     </IfModule>
     #LoadModule dav_fs_module modules/mod_dav_fs.so
     #LoadModule dav_lock_module modules/mod_dav_lock.so
@@ -166,9 +170,9 @@ data:
     #
     User daemon
     Group daemon
-    
+
     </IfModule>
-    
+
     # 'Main' server configuration
     #
     # The directives in this section set up the values used by the 'main'
@@ -196,7 +200,7 @@ data:
     # If your host doesn't have a registered DNS name, enter its IP address here.
     #
     #ServerName www.example.com:80
-    
+
     #
     # Deny access to the entirety of your server's filesystem. You must
     # explicitly permit access to web content directories in other
@@ -206,14 +210,14 @@ data:
         AllowOverride none
         Require all denied
     </Directory>
-    
+
     #
     # Note that from this point forward you must specifically allow
     # particular features to be enabled - so if something's not working as
     # you might expect, make sure that you have specifically enabled it
     # below.
     #
-    
+
     #
     # DocumentRoot: The directory out of which you will serve your
     # documents. By default, all requests are taken from this directory, but
@@ -234,7 +238,7 @@ data:
         # for more information.
         #
         Options Indexes FollowSymLinks
-    
+
         #
         # AllowOverride controls what directives may be placed in .htaccess files.
         # It can be "All", "None", or any combination of the keywords:
@@ -243,7 +247,7 @@ data:
         AllowOverride FileInfo
 
         IndexOrderDefault Descending Name
-    
+
         #
         # Controls who can get stuff from this server.
         #
@@ -256,7 +260,7 @@ data:
 
         IndexIgnore HEADER* FOOTER* index.html
     </Directory>
-    
+
     #
     # DirectoryIndex: sets the file that Apache will serve if a directory
     # is requested.
@@ -264,7 +268,7 @@ data:
     <IfModule dir_module>
         DirectoryIndex index.html
     </IfModule>
-    
+
     #
     # The following lines prevent .htaccess and .htpasswd files from being
     # viewed by Web clients.
@@ -272,7 +276,7 @@ data:
     <Files ".ht*">
         Require all denied
     </Files>
-    
+
     #
     # ErrorLog: The location of the error log file.
     # If you do not specify an ErrorLog directive within a <VirtualHost>
@@ -281,14 +285,14 @@ data:
     # container, that host's errors will be logged there and not here.
     #
     ErrorLog /proc/self/fd/2
-    
+
     #
     # LogLevel: Control the number of messages logged to the error_log.
     # Possible values include: debug, info, notice, warn, error, crit,
     # alert, emerg.
     #
     LogLevel warn
-    
+
     <IfModule log_config_module>
         #
         # The following directives define some format nicknames for use with
@@ -296,12 +300,12 @@ data:
         #
         LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
         LogFormat "%h %l %u %t \"%r\" %>s %b" common
-    
+
         <IfModule logio_module>
           # You need to enable mod_logio.c to use %I and %O
           LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
         </IfModule>
-    
+
         #
         # The location and format of the access logfile (Common Logfile Format).
         # If you do not define any access logfiles within a <VirtualHost>
@@ -310,14 +314,14 @@ data:
         # logged therein and *not* in this file.
         #
         CustomLog /proc/self/fd/1 common
-    
+
         #
         # If you prefer a logfile with access, agent, and referer information
         # (Combined Logfile Format) you can use the following directive.
         #
         #CustomLog "logs/access_log" combined
     </IfModule>
-    
+
     <IfModule alias_module>
         #
         # Redirect: Allows you to tell clients about documents that used to
@@ -325,7 +329,7 @@ data:
         # will make a new request for the document at its new location.
         # Example:
         # Redirect permanent /foo http://www.example.com/bar
-    
+
         #
         # Alias: Maps web paths into filesystem paths and is used to
         # access content that does not live under the DocumentRoot.
@@ -336,7 +340,7 @@ data:
         # require it to be present in the URL.  You will also likely
         # need to provide a <Directory> section to allow access to
         # the filesystem path.
-    
+
         #
         # ScriptAlias: This controls which directories contain server scripts.
         # ScriptAliases are essentially the same as Aliases, except that
@@ -346,9 +350,9 @@ data:
         # directives as to Alias.
         #
         ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
-    
+
     </IfModule>
-    
+
     <IfModule cgid_module>
         #
         # ScriptSock: On threaded servers, designate the path to the UNIX
@@ -356,7 +360,7 @@ data:
         #
         #Scriptsock cgisock
     </IfModule>
-    
+
     #
     # "/usr/local/apache2/cgi-bin" should be changed to whatever your ScriptAliased
     # CGI directory exists, if you have that configured.
@@ -366,7 +370,7 @@ data:
         Options None
         Require all granted
     </Directory>
-    
+
     <IfModule headers_module>
         #
         # Avoid passing HTTP_PROXY environment to CGI's on this or any proxied
@@ -375,14 +379,14 @@ data:
         #
         RequestHeader unset Proxy early
     </IfModule>
-    
+
     <IfModule mime_module>
         #
         # TypesConfig points to the file containing the list of mappings from
         # filename extension to MIME-type.
         #
         TypesConfig conf/mime.types
-    
+
         #
         # AddType allows you to add to or override the MIME configuration
         # file specified in TypesConfig for specific file types.
@@ -400,7 +404,7 @@ data:
         #
         AddType application/x-compress .Z
         AddType application/x-gzip .gz .tgz
-    
+
         #
         # AddHandler allows you to map certain file extensions to "handlers":
         # actions unrelated to filetype. These can be either built into the server
@@ -410,10 +414,10 @@ data:
         # (You will also need to add "ExecCGI" to the "Options" directive.)
         #
         #AddHandler cgi-script .cgi
-    
+
         # For type maps (negotiated resources):
         #AddHandler type-map var
-    
+
         #
         # Filters allow you to process content before it is sent to the client.
         #
@@ -423,14 +427,14 @@ data:
         #AddType text/html .shtml
         #AddOutputFilter INCLUDES .shtml
     </IfModule>
-    
+
     #
     # The mod_mime_magic module allows the server to use various hints from the
     # contents of the file itself to determine its type.  The MIMEMagicFile
     # directive tells the module where the hint definitions are located.
     #
     #MIMEMagicFile conf/magic
-    
+
     #
     # Customizable error responses come in three flavors:
     # 1) plain text 2) local redirects 3) external redirects
@@ -441,14 +445,14 @@ data:
     #ErrorDocument 404 "/cgi-bin/missing_handler.pl"
     #ErrorDocument 402 http://www.example.com/subscription_info.html
     #
-    
+
     #
     # MaxRanges: Maximum number of Ranges in a request before
     # returning the entire resource, or one of the special
     # values 'default', 'none' or 'unlimited'.
     # Default setting is to accept 200 Ranges.
     #MaxRanges unlimited
-    
+
     #
     # EnableMMAP and EnableSendfile: On systems that support it,
     # memory-mapping or the sendfile syscall may be used to deliver
@@ -460,49 +464,49 @@ data:
     #
     EnableMMAP off
     #EnableSendfile on
-    
+
     # Supplemental configuration
     #
     # The configuration files in the conf/extra/ directory can be
     # included to add extra features or to modify the default configuration of
     # the server, or you may simply copy their contents here and change as
     # necessary.
-    
+
     # Server-pool management (MPM specific)
     #Include conf/extra/httpd-mpm.conf
-    
+
     # Multi-language error messages
     #Include conf/extra/httpd-multilang-errordoc.conf
-    
+
     # Fancy directory listings
     #Include conf/extra/httpd-autoindex.conf
-    
+
     # Language settings
     #Include conf/extra/httpd-languages.conf
-    
+
     # User home directories
     #Include conf/extra/httpd-userdir.conf
-    
+
     # Real-time info on requests and configuration
     #Include conf/extra/httpd-info.conf
-    
+
     # Virtual hosts
     #Include conf/extra/httpd-vhosts.conf
-    
+
     # Local access to the Apache HTTP Server Manual
     #Include conf/extra/httpd-manual.conf
-    
+
     # Distributed authoring and versioning (WebDAV)
     #Include conf/extra/httpd-dav.conf
-    
+
     # Various default settings
     #Include conf/extra/httpd-default.conf
-    
+
     # Configure mod_proxy_html to understand HTML4/XHTML1
     <IfModule proxy_html_module>
     Include conf/extra/proxy-html.conf
     </IfModule>
-    
+
     # Secure (SSL/TLS) connections
     #Include conf/extra/httpd-ssl.conf
     #

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -244,7 +244,7 @@ data:
         # It can be "All", "None", or any combination of the keywords:
         #   AllowOverride FileInfo AuthConfig Limit
         #
-        AllowOverride FileInfo
+        AllowOverride FileInfo Indexes
 
         IndexOrderDefault Descending Name
 

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -157,8 +157,8 @@ data:
     #LoadModule speling_module modules/mod_speling.so
     #LoadModule userdir_module modules/mod_userdir.so
     LoadModule alias_module modules/mod_alias.so
-    #LoadModule rewrite_module modules/mod_rewrite.so
-    
+    LoadModule rewrite_module modules/mod_rewrite.so
+
     <IfModule unixd_module>
     #
     # If you wish httpd to run as a different user or group, you must run


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR updates the default `httpd` configuration to be tailored to the Jenkins mirrorbits usage as it is the only known usage.

It is a "short term" fix to ensure we can get started with the new Update Center using the `mirrorbits-parent` chart.

A long term fix would be either to add a feature to `httpd` chart to specify its custom conf through confimap setup, or even better: switch to bitnami's `httpd` chart to benefit from other production ready behaviors (read only, non root, etc.).