### PR TITLE
feat(ldap) allow customization of the LB service for Azure

### DIFF
--- a/charts/ldap/Chart.yaml
+++ b/charts/ldap/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for ldap.jenkins.io
 maintainers:
 - name: olblak
 name: ldap
-version: 0.2.1
+version: 0.3.0

--- a/charts/ldap/templates/service.yaml
+++ b/charts/ldap/templates/service.yaml
@@ -4,13 +4,22 @@ metadata:
   name: {{ include "ldap.fullname" . }}
   labels:
 {{ include "ldap.labels" . | indent 4 }}
+  {{- if and .Values.service.azurePip (or .Values.service.azurePip.name .Values.service.azurePip.resourceGroup)}}
+  annotations:
+    {{- if and .Values.service.azurePip .Values.service.azurePip.name }}
+    service.beta.kubernetes.io/azure-pip-name: {{ .Values.service.azurePip.name }}
+    {{- end }}
+    {{- if and .Values.service.azurePip .Values.service.azurePip.resourceGroup }}
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: {{ .Values.service.azurePip.resourceGroup }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.IP }}
   loadBalancerIP: {{ .Values.service.IP }}
   {{- end }}
-  loadBalancerSourceRanges: 
+  loadBalancerSourceRanges:
     {{- range .Values.service.whitelisted_sources }}
     - {{ . | quote }}
     {{- end }}

--- a/charts/ldap/tests/custom_values_test.yaml
+++ b/charts/ldap/tests/custom_values_test.yaml
@@ -1,13 +1,14 @@
 suite: Test with custom values
 templates:
   - secret.yaml
+  - service.yaml
 tests:
   - it: should create a Secret with the correct value
     set:
       ldap:
         storage:
           accountname: name
-          accountkey: key 
+          accountkey: key
     template: secret.yaml
     asserts:
       - hasDocuments:
@@ -20,3 +21,62 @@ tests:
       - equal:
           path: data.azurestorageaccountkey
           value: a2V5
+  - it: should create a custom service of type loadbalancer with legacy loadbalancerIP field
+    template: service.yaml
+    set:
+      service:
+        IP: 128.129.0.12
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: Service
+    - equal:
+        path: metadata.name
+        value: RELEASE-NAME-ldap
+    - equal:
+        path: spec.type
+        value: LoadBalancer
+    - equal:
+        path: spec.ports[0].port
+        value: 636
+    - equal:
+        path: spec.ports[0].targetPort
+        value: 636
+    - equal:
+        path: spec.selector["app.kubernetes.io/name"]
+        value: ldap
+    - equal:
+        path: spec.selector["app.kubernetes.io/instance"]
+        value: RELEASE-NAME
+    - equal:
+        path: spec.loadBalancerIP
+        value: 128.129.0.12
+    - notExists:
+        path: metadata.annotations
+  - it: should create a custom service of type loadbalancer with modern AKS annotation for public IP
+    template: service.yaml
+    set:
+      service:
+        azurePip:
+          name: myAKSPublicIP
+          resourceGroup: myNetworkResourceGroup
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: Service
+    - equal:
+        path: metadata.name
+        value: RELEASE-NAME-ldap
+    - equal:
+        path: spec.type
+        value: LoadBalancer
+    - notExists:
+        path: spec.loadBalancerIP
+    - equal:
+        path: metadata.annotations["service.beta.kubernetes.io/azure-load-balancer-resource-group"]
+        value: myNetworkResourceGroup
+    - equal:
+        path: metadata.annotations["service.beta.kubernetes.io/azure-pip-name"]
+        value: myAKSPublicIP

--- a/charts/ldap/tests/defaults_values_test.yaml
+++ b/charts/ldap/tests/defaults_values_test.yaml
@@ -1,7 +1,8 @@
 suite: Test with default values
 templates:
-- certificate.yaml
-- persistentVolumeClaim.yaml
+  - certificate.yaml
+  - persistentVolumeClaim.yaml
+  - service.yaml
 tests:
   - it: should create a certificate for the dns ldap.jenkins.io
     template: certificate.yaml
@@ -43,3 +44,33 @@ tests:
         path: metadata.name
         value: RELEASE-NAME-ldap-data
       documentIndex: 1
+  - it: should create a service of type loadbalancer with defaults
+    template: service.yaml
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: Service
+    - equal:
+        path: metadata.name
+        value: RELEASE-NAME-ldap
+    - equal:
+        path: spec.type
+        value: LoadBalancer
+    - equal:
+        path: spec.ports[0].port
+        value: 636
+    - equal:
+        path: spec.ports[0].targetPort
+        value: 636
+    - equal:
+        path: spec.selector["app.kubernetes.io/name"]
+        value: ldap
+    - equal:
+        path: spec.selector["app.kubernetes.io/instance"]
+        value: RELEASE-NAME
+    - notExists:
+        path: spec.loadBalancerIP
+    - notExists:
+        path: metadata.annotations
+


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3683#issuecomment-1798182954

Checked on the production with the following values:

```
service:
  type: LoadBalancer
  # Public IPv4 defined as code in https://github.com/jenkins-infra/azure/blob/main/ldap.jenkins.io.tf instead of requesting a random new public IP, useful for DNS setup and changes
  azurePip:
    name: ldap-jenkins-io-ipv4
    resourceGroup: prod-public-ips
  whitelisted_sources:
# ...
```

result is:

```
ldap, ldap, Service (v1) has changed:
...
    labels:
      app.kubernetes.io/name: ldap
-     helm.sh/chart: ldap-0.2.1
+     helm.sh/chart: ldap-0.3.0
      app.kubernetes.io/instance: ldap
      app.kubernetes.io/managed-by: Helm
+   annotations:
+     service.beta.kubernetes.io/azure-pip-name: ldap-jenkins-io-ipv4
+     service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
  spec:
    type: LoadBalancer
-   loadBalancerIP: 20.7.180.148
    loadBalancerSourceRanges:
      - "20.85.71.108/32"
```