### PR TITLE
feat!(ipv6LBservice): change annotations for azurepipname and ResourceGroup

### DIFF
--- a/charts/ipv6-lb-service/Chart.yaml
+++ b/charts/ipv6-lb-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ipv6-lb-service
 description: A Helm chart for Kubernetes to add an additional LB service dedicated to IPv6
 type: application
-version: 0.1.0
+version: 1.0.0

--- a/charts/ipv6-lb-service/templates/ipv6-lb-service.yaml
+++ b/charts/ipv6-lb-service/templates/ipv6-lb-service.yaml
@@ -3,7 +3,12 @@ kind: Service
 metadata:
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "false"
-    service.beta.kubernetes.io/azure-load-balancer-ipv6: {{ .Values.ipv6 | quote }}
+    {{- if .Values.ipv6PipName }}
+    service.beta.kubernetes.io/azure-pip-name: {{ .Values.ipv6PipName | quote }}
+    {{- end }}
+    {{- if .Values.resourceGroup }}
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: {{ .Values.resourceGroup }}
+    {{- end }}
   labels:
     app.kubernetes.io/component: {{ .Values.app.component }}
     app.kubernetes.io/instance: {{ .Values.app.instance }}

--- a/charts/ipv6-lb-service/values.yaml
+++ b/charts/ipv6-lb-service/values.yaml
@@ -1,4 +1,5 @@
-ipv6: ""
+ipv6PipName: ""
+resourceGroup: ""
 app:
   name: ""
   component: ""


### PR DESCRIPTION
Blocks https://github.com/jenkins-infra/kubernetes-management/pull/4647

tested locally with ipv6-lb-service charts version 1.0.0 :
```
      service.beta.kubernetes.io/azure-load-balancer-internal: "false"
-     service.beta.kubernetes.io/azure-load-balancer-ipv6: "2603:1030:408:5::15a"
+     service.beta.kubernetes.io/azure-pip-name: "public-publick8s-ipv4"
+     service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
    labels:
      app.kubernetes.io/component: controller
 ```