### PR TITLE
[artifact-caching-proxy] Add optional `env` and `envFrom` sections

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.15.1
+version: 0.16.1

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -69,9 +69,13 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
-          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- toYaml .Values.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          {{- toYaml .Values.env | nindent 10 }}
+        envFrom:
+          {{- toYaml .Values.envFrom | nindent 10 }}
         ports:
           - name: http
             containerPort:  {{ .Values.service.port }}

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -3,7 +3,33 @@ templates:
   - ingress-health.yaml
   - ingress.yaml
   - pdb.yaml
+  - statefulset.yaml
+  - nginx-default-configmap.yaml
+  - nginx-proxy-configmap.yaml
 tests:
+  - it: Should set a custom env and envFrom when specified by values
+    template: statefulset.yaml
+    set:
+      env:
+        - name: DEMO_GREETING
+          value: "Hello from the environment"
+      envFrom:
+        - secretRef:
+            name: demo-greeting
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "DEMO_GREETING"
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "Hello from the environment"
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: "demo-greeting"
   - it: Should set a custom health check path when specified by values
     template: ingress.yaml
     set:

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -38,6 +38,12 @@ tests:
       - notExists:
           path: spec.affinity
       - equal:
+          path: spec.template.spec.containers[0].env
+          value: []
+      - equal:
+          path: spec.template.spec.containers[0].envFrom
+          value: []
+      - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: artifact-caching-proxy
       - equal:

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -91,3 +91,11 @@ proxy:
     enabled: false
 poddisruptionbudget:
   minAvailable: 1
+env: []
+# - name: http_proxy
+#   value: "http://my-nginx-forward-proxy:3128"
+# - name: no_proxy
+#   value: "localhost,127.0.0.1,172.17.0.1"
+envFrom: []
+# - secretRef:
+#     name: my-nginx-proxy-secrets


### PR DESCRIPTION
Adds optional `env` and `envFrom` sections to chart

This allows us to further configure the nginx proxy.
