### PR TITLE
feat(rsyncd): remove the sha corresponding to amd64 to enable arm64 images

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 1.4.8
+version: 1.4.9
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/values.yaml
+++ b/charts/rsyncd/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: jenkinsciinfra/rsyncd
-  tag: 1.0.13@sha256:d3ed3a8438f0927b5b5e518a53feb098e4d7520433aa20ec20c7398830bb6245
+  tag: 1.0.13
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/updatecli/updatecli.d/rsyncd.yaml
+++ b/updatecli/updatecli.d/rsyncd.yaml
@@ -13,29 +13,26 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  latestDockerRsyncdRelease:
-    kind: githubrelease
-    name: Get latest docker-rsyncd released version
-    spec:
-      owner: jenkins-infra
-      repository: docker-rsyncd
-      token: "{{ requiredEnv .github.token }}"
-  latestDockerRsyncdDigest:
-    kind: dockerdigest
-    name: "Get jenkinsciinfra/rsyncd:latest docker image digest"
-    dependson:
-      - latestDockerRsyncdRelease
+  latestDockerRsyncdImage:
+    kind: dockerimage
+    name: "Get jenkinsciinfra/rsyncd:latest docker image version (arm64/amd64)"
     spec:
       image: "jenkinsciinfra/rsyncd"
-      tag: '{{ source "latestDockerRsyncdRelease" }}'
-      architecture: "amd64"
+      versionfilter:
+        kind: "semver"
 
-# no condition to test rsyncd docker image availability as we're using a digest from docker hub
+conditions:
+   docker:
+    name: "Docker Image Published on Registry"
+    kind: dockerimage
+    spec:
+      image: "jenkinsciinfra/rsyncd"
+      architectures: ["linux/amd64","linux/arm64"]
 
 targets:
   updateRsyncd:
     name: "Update rsyncd docker image version"
-    sourceid: latestDockerRsyncdDigest
+    sourceid: latestDockerRsyncdImage
     kind: helmchart
     spec:
       name: charts/rsyncd


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1816831551
and https://github.com/jenkins-infra/kubernetes-management/pull/4691