### PR TITLE
chore(gha/release): pass GitHub Token to `azure/setup-helm` and increase its version precision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Needed for mirrorbits-parent subchart dependencies
       - name: Add jenkins-infra Helm repository
         run: helm repo add jenkins-infra https://jenkins-infra.github.io/helm-charts


### PR DESCRIPTION
Looking at last release GHA builds like https://github.com/jenkins-infra/helm-charts/actions/runs/6932409633, we can see the following error:

> Error while fetching latest Helm release: Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`. See https://github.com/octokit/auth-action.js#createactionauth. Using default version v3.9.0


This PR fixes this by passing the GitHub token as recommended by the GHA documentation in case we're fetching the 'latest' helm release: https://github.com/Azure/setup-helm#example

It also increase the version precision to v3.5 (the current pinned version).