### PR TITLE
feat(gha/release): add commit subject as chart release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,56 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
-      # Needed for mirrorbits-parent subchart dependencies
+
+      # Needed for subchart dependencies
       - name: Add jenkins-infra Helm repository
         run: helm repo add jenkins-infra https://jenkins-infra.github.io/helm-charts
+
       - name: Run chart-releaser
+        id: chart_releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Update modified chart release(s)
+        id: update_chart_releases
+        if: steps.chart_releaser.outputs.changed_charts != ''
+        run: |
+          # KISS, last commit subject as changelog for every modified chart
+          changelog=$(git log --format=%s -n 1)
+
+          # Set IFS to a comma to split the string into an array
+          IFS=',' read -ra changedCharts <<< "${{ steps.chart_releaser.outputs.changed_charts }}"
+
+          for chart in "${changedCharts[@]}"; do          
+            chartName=$(echo "${chart}" | cut -d '/' -f 2)
+            # Retrieve version from Chart.yaml
+            version=$(yq '.version' "${chart}/Chart.yaml")
+
+            # Retrive release id and body from tag
+            tag="${chartName}-${version}"
+            release=$(curl --location --silent --fail --show-error "https://api.github.com/repos/${{ github.repository }}/releases/tags/${tag}")
+            releaseId=$(echo "${release}" | jq --raw-output '.id')
+            releaseBody=$(echo "${release}" | jq --raw-output '.body')
+
+            # Update release
+            newlines="\r\n\r\n"
+            body="${releaseBody}${newlines}## Changelog${newlines}${changelog}"
+            echo "= release description for ${tag}:"
+            echo "${body}"
+            curl --silent --fail --show-error --output /dev/null --location \
+              -X PATCH \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/${releaseId}" \
+              --data "{\"body\":\"${body}\"}"
+          done


### PR DESCRIPTION
This PR adds the last commit subject as changelog to each chart GitHub release if they've just been released.

Tested on a fork, example:
- Commit: https://github.com/lemeurherve/helm-charts/commit/5330ffac3c7c195f5f33be412b0f66ba3accfdc2
- Release: https://github.com/lemeurherve/helm-charts/releases/tag/basic-helm-chart-example-1.2.3