### PR TITLE
cleanup!(mirrorbit-parent) change dependency to support renaming of `mirrorbits-lite` to `mirrorbits`. BREAKING.

### DIFF
--- a/charts/mirrorbits-parent/Chart.lock
+++ b/charts/mirrorbits-parent/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: mirrorbits-lite
+- name: mirrorbits
   repository: https://jenkins-infra.github.io/helm-charts
-  version: 0.4.1
+  version: 2.0.0
 - name: httpd
   repository: https://jenkins-infra.github.io/helm-charts
-  version: 0.3.0
+  version: 0.3.1
 - name: rsyncd
   repository: https://jenkins-infra.github.io/helm-charts
   version: 1.4.16
-digest: sha256:a0ee02708651c6b7e03efd76eb44922f8754bd9511fb3b10dc670fec6a6d13d4
-generated: "2024-01-08T07:30:20.278477164Z"
+digest: sha256:836608abe104a63a89275f3f8f5b0849a22414d63c41e806902e6f29019ad32f
+generated: "2024-01-09T09:33:12.097869+01:00"

--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,19 +2,19 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 1.1.15
+version: 2.0.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team
 dependencies:
-- name: mirrorbits-lite
-  condition: mirrorbits-lite.enabled
+- name: mirrorbits
+  condition: mirrorbits.enabled
   repository: https://jenkins-infra.github.io/helm-charts
-  version: 0.4.1
+  version: 2.0.0
 - name: httpd
   condition: httpd.enabled
   repository: https://jenkins-infra.github.io/helm-charts
-  version: 0.3.0
+  version: 0.3.1
 - name: rsyncd
   condition: rsyncd.enabled
   repository: https://jenkins-infra.github.io/helm-charts

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -2,7 +2,7 @@
 
 This chart allows to deploys up to three services:
 
-* [mirrorbits](https://github.com/etix/mirrorbits) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits-lite>
+* [mirrorbits](https://github.com/etix/mirrorbits) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits>
 * [httpd (Apache2)](https://httpd.apache.org/) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/httpd>
 * [rsyncd](https://linux.die.net/man/1/rsync) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/rsyncd>
 
@@ -43,7 +43,7 @@ ingress:
       hosts:
         - downloads.company.org
 
-mirrorbits-lite:
+mirrorbits:
   enabled: true
 
 httpd:
@@ -60,7 +60,7 @@ Since the chart was initially designed to run on AKS with an Azurefile volume, p
 Example with an Azure file PV and associated PVC mounted in read only:
 
 ```yaml
-mirrorbits-lite:
+mirrorbits:
   enabled: true
   repository:
     name: <name of the PVC>

--- a/charts/mirrorbits-parent/templates/_helpers.tpl
+++ b/charts/mirrorbits-parent/templates/_helpers.tpl
@@ -58,11 +58,11 @@ Expected argument: dict{
  */}}
 {{- define "mirrorbits-parent.validateIngressBackend" -}}
 {{- if eq .currentBackendService "mirrorbits" -}}
-  {{- if not (index .rootContext.Values "mirrorbits-lite" "enabled") -}}
-    {{- fail "Cannot use mirrorbits-lite as backend if it is disabled." }}
+  {{- if not (index .rootContext.Values "mirrorbits" "enabled") -}}
+    {{- fail "Cannot use mirrorbits as backend if it is disabled." }}
   {{- end -}}
-  {{- if not (index .rootContext.Values "mirrorbits-lite" "backendServiceNameTpl") -}}
-    {{- fail "Cannot determine mirrorbits backend service due to missing value 'mirrorbits-lite.currentBackendServiceNameTpl." }}
+  {{- if not (index .rootContext.Values "mirrorbits" "backendServiceNameTpl") -}}
+    {{- fail "Cannot determine mirrorbits backend service due to missing value 'mirrorbits.currentBackendServiceNameTpl." }}
   {{- end -}}
 {{- else if eq .currentBackendService "httpd" -}}
   {{- if not (index .rootContext.Values "httpd" "enabled") -}}
@@ -86,7 +86,7 @@ Expected argument: dict{
 {{- define "mirrorbits-parent.ingressBackendName" -}}
 {{- include "mirrorbits-parent.validateIngressBackend" . }}
 {{- if eq .currentBackendService "mirrorbits" -}}
-  {{ printf "%s" (tpl (index .rootContext.Values "mirrorbits-lite" "backendServiceNameTpl") .rootContext) | trim | trunc 63 }}
+  {{ printf "%s" (tpl (index .rootContext.Values "mirrorbits" "backendServiceNameTpl") .rootContext) | trim | trunc 63 }}
 {{- else if eq .currentBackendService "httpd" -}}
   {{ printf "%s" (tpl (index .rootContext.Values "httpd" "backendServiceNameTpl") .rootContext) | trim | trunc 63 }}
 {{- end -}}
@@ -102,7 +102,7 @@ Expected argument: dict{
 {{- define "mirrorbits-parent.ingressBackendPort" -}}
 {{- include "mirrorbits-parent.validateIngressBackend" . }}
 {{- if eq .currentBackendService "mirrorbits" -}}
-  {{ index .rootContext.Values "mirrorbits-lite" "service" "port" }}
+  {{ index .rootContext.Values "mirrorbits" "service" "port" }}
 {{- else if eq .currentBackendService "httpd" -}}
   {{ index .rootContext.Values "httpd" "service" "port" }}
 {{- end -}}

--- a/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
@@ -1,9 +1,9 @@
 suite: Tests with custom values
 set:
   ## Mock subcharts default values
-  mirrorbits-lite:
+  mirrorbits:
     enabled: true
-    backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits-lite" }}'
+    backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits" }}'
     service:
       port: 7777
   httpd:
@@ -52,7 +52,7 @@ tests:
           path: spec.rules[1]
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: RELEASE-NAME-mirrorbits-lite
+          value: RELEASE-NAME-mirrorbits
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 7777
@@ -124,7 +124,7 @@ tests:
           value: ImplementationSpecific
       - equal:
           path: spec.rules[0].http.paths[1].backend.service.name
-          value: RELEASE-NAME-mirrorbits-lite
+          value: RELEASE-NAME-mirrorbits
       - equal:
           path: spec.rules[0].http.paths[1].backend.service.port.number
           value: 7777
@@ -179,7 +179,7 @@ tests:
   - it: should fail the ingress when referencing mirrorbits as backend but it is disabled
     template: ingress.yaml
     set:
-      mirrorbits-lite:
+      mirrorbits:
         enabled: false
       global:
         ingress:
@@ -190,4 +190,4 @@ tests:
                   backendService: mirrorbits
     asserts:
       - failedTemplate:
-          errorMessage: "Cannot use mirrorbits-lite as backend if it is disabled."
+          errorMessage: "Cannot use mirrorbits as backend if it is disabled."

--- a/charts/mirrorbits-parent/tests/custom_values_serviceaccount_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_serviceaccount_test.yaml
@@ -1,9 +1,9 @@
 suite: Tests with custom values
 set:
   ## Mock subcharts default values
-  mirrorbits-lite:
+  mirrorbits:
     enabled: true
-    backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits-lite" }}'
+    backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits" }}'
     service:
       port: 7777
   httpd:

--- a/charts/mirrorbits-parent/values.yaml
+++ b/charts/mirrorbits-parent/values.yaml
@@ -70,9 +70,9 @@ global:
       #   ...
 
 ## Sub charts specific values
-mirrorbits-lite:
+mirrorbits:
   enabled: false
-  backendServiceNameTpl: '{{ include "mirrorbits-lite.fullname" (index $.Subcharts "mirrorbits-lite")}}'
+  backendServiceNameTpl: '{{ include "mirrorbits.fullname" (index $.Subcharts "mirrorbits")}}'
 httpd:
   enabled: false
   backendServiceNameTpl: '{{ include "httpd.fullname" (index $.Subcharts "httpd")}}'

--- a/updatecli/updatecli.d/httpd.yaml
+++ b/updatecli/updatecli.d/httpd.yaml
@@ -43,15 +43,6 @@ targets:
       key: $.image.tag
       versionincrement: patch
     scmid: default
-  updateHttpdInMirrorbits:
-    name: "Update httpd docker image version in mirrorbits chart"
-    sourceid: latestRelease
-    kind: helmchart
-    spec:
-      name: charts/mirrorbits
-      key: $.image.files.tag
-      versionincrement: patch
-    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
Follow up of #1006 since https://github.com/jenkins-infra/helm-charts/releases/tag/mirrorbits-2.0.0 has been released.