### PR TITLE
chore(mirrorbits-parent) fix unittest for helm-unittest `v0.4.1`

### DIFF
--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
@@ -1,25 +1,6 @@
 suite: Tests with custom values
-set:
-  ## Mock subcharts default values
-  mirrorbits:
-    enabled: true
-    backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits" }}'
-    service:
-      port: 7777
-  httpd:
-    enabled: true
-    backendServiceNameTpl: '{{ default "RELEASE-NAME-httpd" }}'
-    service:
-      port: 8080
-  ## End of subchart mocked values
-  global:
-    ingress:
-      enabled: true
-      hosts:
-        - host: company.org
-          paths:
-            - path: /
-              backendService: mirrorbits
+values:
+  - values/custom.yaml
 templates:
   - ingress.yaml
 tests:

--- a/charts/mirrorbits-parent/tests/custom_values_storage_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_storage_test.yaml
@@ -1,22 +1,6 @@
 suite: Tests with custom values
-set:
-  global:
-    storage:
-      enabled: true
-      storageClassName: super-fast-storage
-      storageSize: 510Gi
-      accessModes:
-        - ReadWriteMany
-        - ReadOnlyMany
-        - ReadWriteOnce
-      persistentVolume:
-        additionalSpec:
-          persistentVolumeReclaimPolicy: Retain
-          mountOptions:
-            - dir_mode=0755
-      persistentVolumeClaim:
-        additionalSpec:
-          volumeMode: Block
+values:
+  - values/custom.yaml
 templates:
   - persistentvolume.yaml
   - persistentvolumeclaim.yaml

--- a/charts/mirrorbits-parent/tests/values/custom.yaml
+++ b/charts/mirrorbits-parent/tests/values/custom.yaml
@@ -1,0 +1,36 @@
+## Mock subcharts default values
+mirrorbits:
+  enabled: true
+  backendServiceNameTpl: '{{ default "RELEASE-NAME-mirrorbits" }}'
+  service:
+    port: 7777
+httpd:
+  enabled: true
+  backendServiceNameTpl: '{{ default "RELEASE-NAME-httpd" }}'
+  service:
+    port: 8080
+## End of subchart mocked values
+global:
+  ingress:
+    enabled: true
+    hosts:
+      - host: company.org
+        paths:
+          - path: /
+            backendService: mirrorbits
+  storage:
+      enabled: true
+      storageClassName: super-fast-storage
+      storageSize: 510Gi
+      accessModes:
+        - ReadWriteMany
+        - ReadOnlyMany
+        - ReadWriteOnce
+      persistentVolume:
+        additionalSpec:
+          persistentVolumeReclaimPolicy: Retain
+          mountOptions:
+            - dir_mode=0755
+      persistentVolumeClaim:
+        additionalSpec:
+          volumeMode: Block


### PR DESCRIPTION
PR #1011 bumped the helm unittests plugin to [`v0.4.1`](https://github.com/helm-unittest/helm-unittest/releases/tag/v0.4.1).

This version bump made the unittest failing for `mirrorbits-parent` due to https://github.com/helm-unittest/helm-unittest/pull/267: we cannot use "test-scoped" values defined inline with the `set` keyword.

This PR uses a common values files which has the benefit to avoid scattering values over time AND can be overridden per sub test.


Note @lemeurherve , the PR 1011 did not run any check as it detected no chart modification. Do you think it is possible (and easy) to run all unittests if the file in charge of installing the plugin (such as the GHA workflow) is changed?