### PR TITLE
chore(updatecli): small typo in target name (visible in generated PRs)

### DIFF
--- a/updatecli/updatecli.d/mirrorbits-parent.yaml
+++ b/updatecli/updatecli.d/mirrorbits-parent.yaml
@@ -34,7 +34,7 @@ sources:
 
 targets:
   updateMirrorbits:
-    name: Update `mirrorbits`` subchart version
+    name: Update `mirrorbits` subchart version
     sourceid: lastMirrorbitsChartVersion
     kind: helmchart
     spec:


### PR DESCRIPTION
See typo in https://github.com/jenkins-infra/helm-charts/pull/1016 for example:
<img width="469" alt="image" src="https://github.com/jenkins-infra/helm-charts/assets/91831478/313f02f4-6732-49c5-acf1-3fb06d0ee567">
