### PR TITLE
fix(GHA/test): proper `modifiedWorkflow` init if empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,13 @@ jobs:
             modifiedChartPaths=$(echo ${modifiedPaths} | xargs dirname | grep "^charts/" | cut -d "/" -f1-2 | sort --unique)
 
             # Test all charts if this workflow has been modified
-            modifiedWorkflow=$(echo ${modifiedPaths} | grep ".github/workflows/test.yml")
+            modifiedWorkflow=$(echo ${modifiedPaths} | grep ".github/workflows/test.yml" || echo "")
             if [ -n "${modifiedWorkflow}" ]; then
               modifiedChartPaths=$allChartsPaths
               echo "= workflow modified, including all charts"
             fi
 
-            echo "= list of modified chart name(s) from the pull request: $modifiedChartPaths"
+            echo "= list of modified chart(s) from the pull request: $modifiedChartPaths"
           fi
 
           # Keep only modified charts with unit tests


### PR DESCRIPTION
This PR properly initialize the `modifiedWorkflow` variable with an empty string if there is no match.
(Still not sure why this fails here and not in other similar lines which can also be empty 🤷)

Tested extensively on my fork.

Fixup of:
- #1014 
- #1020