### PR TITLE
update jenkinsio charts and readme

### DIFF
--- a/charts/jenkinsio/Chart.yaml
+++ b/charts/jenkinsio/Chart.yaml
@@ -4,4 +4,4 @@ maintainers:
 - name: timja
 - name: dduportal
 name: jenkinsio
-version: 1.1.0
+version: 1.1.1

--- a/charts/jenkinsio/README.md
+++ b/charts/jenkinsio/README.md
@@ -6,13 +6,20 @@ This chart deploys https://jenkins.io
 
 This guide assumes you're running minikube, adjust accordingly if you're using something else to run it.
 
-First you need to download the latest jenkins.io site build, the files will be git ignored.
+First you need to build the latest jenkins.io site from source.
+```bash
+# clone the jenkins.io repo: 
+git clone https://github.com/jenkins-infra/jenkins.io.git
+# build archive file
+cd jenkins.io
+make archive
+```
 
-Navigate to: `https://ci.jenkins.io/job/Infra/job/jenkins.io/job/master/`
-Download the latest `jenkins.io-<number>.zip`
+`make archive` should generate a `jenkins.io-<number>.zip` in `build/archives`.
+
 
 ```bash
-cd charts/jenkins.io
+cd charts/jenkinsio
 unzip jenkins.io-<number>.zip
 mv jenkins.io-* site/
 mkdir -p site-zh/
@@ -22,7 +29,7 @@ minikube mount site-zh:/hostzh
 ```
 
 ```yaml
-helm install -f values.yaml -f values.local.yaml --name jenkinsio .
+helm install -f values.yaml -f values.local.yaml jenkinsio .
 ```
 
 ```yaml

--- a/charts/jenkinsio/templates/ingress.yaml
+++ b/charts/jenkinsio/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .service.name }}
+                name: {{ .serviceName }}
                 port:
                   number: {{ $svcPort }}
         {{- end }}

--- a/charts/jenkinsio/templates/ingress.yaml
+++ b/charts/jenkinsio/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ .serviceName }}
+                name: {{ .service.name }}
                 port:
                   number: {{ $svcPort }}
         {{- end }}


### PR DESCRIPTION
This PR fixes the deployment error for chart jenkinsio which throws 
``` 
Error: INSTALLATION FAILED: 1 error occurred:
	* Ingress.extensions "jenkinsio" is invalid: [spec.rules[0].http.paths[0].backend.service.name: Required value, spec.rules[0].http.paths[1].backend.service.name: Required value]
```

Also updates the outdated instructions on https://github.com/jenkins-infra/helm-charts/tree/main/charts/jenkinsio#running-this-yourself

https://github.com/jenkins-infra/helm-charts/issues/944