### PR TITLE
feat(incrementals-publisher) allow customizing permissions URL

### DIFF
--- a/charts/incrementals-publisher/Chart.yaml
+++ b/charts/incrementals-publisher/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: incrementals-publisher
 name: incrementals-publisher
-version: 0.6.12
+version: 0.7.0

--- a/charts/incrementals-publisher/templates/deployment.yaml
+++ b/charts/incrementals-publisher/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "incrementals-publisher.fullname" . }}
                   key: preshared_key
+            {{- if .Values.permissions_url }}
+            - name: PERMISSIONS_URL
+              value: {{ .Values.permissions_url }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/incrementals-publisher/tests/custom_values_test.yaml
+++ b/charts/incrementals-publisher/tests/custom_values_test.yaml
@@ -1,0 +1,35 @@
+suite: Custom values
+templates:
+  - deployment.yaml
+  - secret.yaml # dependency of deployment.yaml
+values:
+  # These values are required by the template "secret.yaml"
+  - secret-values.yaml
+set:
+  permissions_url: https://somewhere.jenkins.io/github.json
+tests:
+  - it: should define a deployment with the provided custom settings
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: incrementals-publisher
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PRESHARED_KEY
+            valueFrom:
+              secretKeyRef:
+                key: preshared_key
+                name: RELEASE-NAME-incrementals-publisher
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PERMISSIONS_URL
+            value: https://somewhere.jenkins.io/github.json
+          any: true

--- a/charts/incrementals-publisher/tests/defaults_test.yaml
+++ b/charts/incrementals-publisher/tests/defaults_test.yaml
@@ -1,0 +1,32 @@
+suite: Default values
+templates:
+  - deployment.yaml
+  - secret.yaml # dependency of deployment.yaml
+values:
+  # These values are required by the template "secret.yaml"
+  - secret-values.yaml
+tests:
+  - it: should define a deployment with the default settings
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: incrementals-publisher
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PRESHARED_KEY
+            valueFrom:
+              secretKeyRef:
+                key: preshared_key
+                name: RELEASE-NAME-incrementals-publisher
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PERMISSIONS_URL
+          any: true

--- a/charts/incrementals-publisher/tests/secret-values.yaml
+++ b/charts/incrementals-publisher/tests/secret-values.yaml
@@ -1,0 +1,11 @@
+# These values are required by the template "secret.yaml"
+# (their default value is "empty" which fails the chart)
+artifactory:
+  key: superSecretKey
+github:
+  token: superSecretToken
+  appId: superSecretID
+  privateKey: superSecretKey
+jenkins:
+  auth: secretJenkinsUser:superSecretJenkinsUserPass
+preshared_key: superSecretPreSharedKey

--- a/charts/incrementals-publisher/values.yaml
+++ b/charts/incrementals-publisher/values.yaml
@@ -45,6 +45,8 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+# permissions_url -- URL to the JSON file providing permissions from the Repository Permission Updater system
+permissions_url: ''
 artifactory:
   # artifactory.key -- key to upload to artifactory
   key: ''

--- a/charts/incrementals-publisher/values.yaml
+++ b/charts/incrementals-publisher/values.yaml
@@ -46,6 +46,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 # permissions_url -- URL to the JSON file providing permissions from the Repository Permission Updater system
+# See default value at https://github.com/jenkins-infra/incrementals-publisher/?tab=readme-ov-file#environment-variables
 permissions_url: ''
 artifactory:
   # artifactory.key -- key to upload to artifactory


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3955

This PR introduces a new feature on the `incrementals-publisher` chart: the permissions URL can be specified through helm values (to override the default value in the app through environment variable).


- Unit tested (of course)
- Tested with a local k3s cluster and 2 scenarios:
  - Cluster creation:

    <details>
      <summary>Click me to expand and view details</summary>
      
      ```bash
      $ cat .tmp/k3d.yaml 
      apiVersion: k3d.io/v1alpha5
      kind: Simple
      metadata:
        name: jenkins-infra
      servers: 1
      agents: 2
      image: rancher/k3s:v1.26.13-k3s2
      ports:
        - port: 80:80
          nodeFilters:
            - loadbalancer
        - port: 443:443
          nodeFilters:
            - loadbalancer
        - port: 8080:8080
          nodeFilters:
            - loadbalancer
      options:
        k3s:
          extraArgs:
            - arg: "--disable=traefik"
              nodeFilters:
                - server:*
      $ k3d create --config=.tmp/k3d.yaml
      ```

    </details>

  - Scenario 1: nominal with a valid URL:

    <details>
      <summary>Click me to expand and view details</summary>
    
    ```diff
    diff --git a/clusters/publick8s.yaml b/clusters/publick8s.yaml
    index 9c04745f..4fa4ab17 100644
    --- a/clusters/publick8s.yaml
    +++ b/clusters/publick8s.yaml
    @@ -153,8 +153,8 @@ releases:
           - "../secrets/config/plugin-health-scoring/secrets.yaml"
       - name: incrementals-publisher
         namespace: incrementals-publisher
    -    chart: jenkins-infra/incrementals-publisher
    -    version: 0.6.12
    +    chart: ../../helm-charts/charts/incrementals-publisher
    +    # version: 0.6.12
         values:
           - "../config/incrementals-publisher.yaml"
         secrets:
    diff --git a/config/incrementals-publisher.yaml b/config/incrementals-publisher.yaml
    index b2feda31..eef5765a 100644
    --- a/config/incrementals-publisher.yaml
    +++ b/config/incrementals-publisher.yaml
    @@ -1,5 +1,5 @@
     ingress:
    -  enabled: true
    +  enabled: false
       className: public-nginx
       annotations:
         "cert-manager.io/cluster-issuer": "letsencrypt-prod"
    @@ -13,11 +13,13 @@ ingress:
           hosts:
             - incrementals.jenkins.io
     
    -nodeSelector:
    -  kubernetes.io/arch: arm64
    +permissions_url: https://reports.jenkins.io/github.index.json
     
    -tolerations:
    -  - key: "kubernetes.io/arch"
    -    operator: "Equal"
    -    value: "arm64"
    -    effect: "NoSchedule"
    +# nodeSelector:
    +#   kubernetes.io/arch: arm64
    +
    +# tolerations:
    +#   - key: "kubernetes.io/arch"
    +#     operator: "Equal"
    +#     value: "arm64"
    +#     effect: "NoSchedule"
    ```
    
    ```bash
    # Requires secrets to be set of course (GPG)
    $ helmfile apply -f ./clusters/publick8s.yaml -l name=incrementals-publisher
    ```
    
    </details>
    
    ```
    # Once installed, exec into the container. Note the redacted token retrieved from ci.jenkins.io
    $ curl --verbose -request POST --data '{"build_url":"https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master/221/"}' --header 'Authorization: Bearer <redacted>' --header "Content-Type: application/json" http://localhost:3000
    
    ## Work and generated a valid incrementals
    ```

  - Scenario 2: invalid URL for permissions

    <details>
      <summary>Click me to expand and view details</summary>
    
    ```diff
    diff --git a/clusters/publick8s.yaml b/clusters/publick8s.yaml
    index 9c04745f..4fa4ab17 100644
    --- a/clusters/publick8s.yaml
    +++ b/clusters/publick8s.yaml
    @@ -153,8 +153,8 @@ releases:
           - "../secrets/config/plugin-health-scoring/secrets.yaml"
       - name: incrementals-publisher
         namespace: incrementals-publisher
    -    chart: jenkins-infra/incrementals-publisher
    -    version: 0.6.12
    +    chart: ../../helm-charts/charts/incrementals-publisher
    +    # version: 0.6.12
         values:
           - "../config/incrementals-publisher.yaml"
         secrets:
    diff --git a/config/incrementals-publisher.yaml b/config/incrementals-publisher.yaml
    index b2feda31..eef5765a 100644
    --- a/config/incrementals-publisher.yaml
    +++ b/config/incrementals-publisher.yaml
    @@ -1,5 +1,5 @@
     ingress:
    -  enabled: true
    +  enabled: false
       className: public-nginx
       annotations:
         "cert-manager.io/cluster-issuer": "letsencrypt-prod"
    @@ -13,11 +13,13 @@ ingress:
           hosts:
             - incrementals.jenkins.io
     
    -nodeSelector:
    -  kubernetes.io/arch: arm64
    +permissions_url: https://nopenopenope.jenkins.io/github.index.json
     
    -tolerations:
    -  - key: "kubernetes.io/arch"
    -    operator: "Equal"
    -    value: "arm64"
    -    effect: "NoSchedule"
    +# nodeSelector:
    +#   kubernetes.io/arch: arm64
    +
    +# tolerations:
    +#   - key: "kubernetes.io/arch"
    +#     operator: "Equal"
    +#     value: "arm64"
    +#     effect: "NoSchedule"
    ```
    
    ```bash
    # Requires secrets to be set of course (GPG)
    $ helmfile apply -f ./clusters/publick8s.yaml -l name=incrementals-publisher
    ```

    </details>

    ```
    # Once installed, exec into the container. Note the redacted token retrieved from ci.jenkins.io
    $ curl --verbose -request POST --data '{"build_url":"https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master/221/"}' --header 'Authorization: Bearer <redacted>' --header "Content-Type: application/json" http://localhost:3000
    
    ## Failed (pod killed with exit code 137 and a log about the URL https://nopenopenope.jenkins.io/github.index.json not existing
    ```
