### PR TITLE
 feat(jenkins-jobs) add GitHub scm custom notification to ensure distinct checks for each job

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -109,6 +109,10 @@ tests:
                             repoOwner('jenkins-infra')
                             repository('child-job')
                             traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/parent-folder/child-job')
+                                typeSuffix(true)
+                              }
                               gitHubSCMSourceStatusChecksTrait {
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -39,6 +39,10 @@ tests:
                             repoOwner('jenkins-infra')
                             repository('default-job')
                             traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/default-job')
+                                typeSuffix(true)
+                              }
                               gitHubSCMSourceStatusChecksTrait {
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
@@ -117,6 +121,7 @@ tests:
                   }
   - it: should generate a multibranch job with custom name, description and explicit kind
     set:
+      jenkinsFqdn: jenkins.company.com
       jobsDefinition:
         joba:
           name: Job A
@@ -146,6 +151,10 @@ tests:
                             repoOwner('jenkins-infra')
                             repository('joba')
                             traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/jenkins.company.com/joba')
+                                typeSuffix(true)
+                              }
                               gitHubSCMSourceStatusChecksTrait {
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
@@ -256,6 +265,10 @@ tests:
                             repoOwner('obiwankenobi')
                             repository('lightsaber')
                             traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/job-b')
+                                typeSuffix(true)
+                              }
                               gitHubSCMSourceStatusChecksTrait {
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
@@ -367,6 +380,10 @@ tests:
                             repoOwner('jenkins-infra')
                             repository('job-c')
                             traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/job-c')
+                                typeSuffix(true)
+                              }
                               gitHubSCMSourceStatusChecksTrait {
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('untrusted-ci')


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2778#issuecomment-1959565465

This PR proposes the following:

GitHub checks default notification is changed from `continuous-integration/jenkins/pr-merge` to the following pattern:

`jenkins/<Jenkins FQDN>/<Full Job Identifier>` where:

- <Jenkins FQDN> is passed by helm values or defaults to "localhost"
- <Full Job Identifier> is automatically set to the full Jenkins internal Job ID (string with '/' separators when recursive job structure such as folders or multibranch jobs)




Example with a diff on the infra.ci.jenkins.io setup:

- Principal job for jenkins-infra/packer-images:

```diff
+                       gitHubNotificationContextTrait {
+                         contextLabel('jenkins/infra.ci.jenkins.io/infra-tools/packer-images')
+                         typeSuffix(true)
+                       }
```

- Secondary (updatecli) job for jenkins-infra/packer-images:

```diff
+                       gitHubNotificationContextTrait {
+                         contextLabel('jenkins/infra.ci.jenkins.io/updatecli/packer-images')
+                         typeSuffix(true)
+                       }
```


Pros:

- Less configuration: the notifications for secondary jobs do NOT require a custom static string (like the current GH check "Updatecli (infra.ci.jenkins.io)" check name on each job
- Supports more than 2 multibranch jobs per repository

Cons:

- Naming depends on the Jenkins controller structure: it changes per repository