### PR TITLE
fix(jenkins.io): don't hardcode `jenkinsio` resource name and references

### DIFF
--- a/charts/jenkinsio/Chart.yaml
+++ b/charts/jenkinsio/Chart.yaml
@@ -4,4 +4,4 @@ maintainers:
 - name: timja
 - name: dduportal
 name: jenkinsio
-version: 1.1.2
+version: 1.1.3

--- a/charts/jenkinsio/templates/deployment.yaml
+++ b/charts/jenkinsio/templates/deployment.yaml
@@ -74,4 +74,4 @@ spec:
 {{- end }}
         - name: config
           configMap:
-            name: jenkinsio
+            name: {{ include "jenkinsio.fullname" . }}

--- a/charts/jenkinsio/templates/secret.yaml
+++ b/charts/jenkinsio/templates/secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: jenkinsio
+  name: {{ include "jenkinsio.fullname" . }}
 type: Opaque
 data:
   azurestorageaccountname: {{ .Values.azureStorageAccountName | b64enc }}

--- a/charts/jenkinsio/templates/zh-deployment.yaml
+++ b/charts/jenkinsio/templates/zh-deployment.yaml
@@ -73,4 +73,4 @@ spec:
 {{- end }}
         - name: config
           configMap:
-            name: jenkinsio
+            name: {{ include "jenkinsio.fullname" . }}


### PR DESCRIPTION
While working on jenkins.io storage account replacement, I noticed that some refs are hardcoded, and prevent deploying this chart under another release name than `jenkinsio`. This PR fixes that.

Related:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1961011896