### PR TITLE
feat(jenkins.io): allow disabling either jenkins.io or zh-jenkins.io

### DIFF
--- a/charts/jenkinsio/Chart.yaml
+++ b/charts/jenkinsio/Chart.yaml
@@ -4,4 +4,4 @@ maintainers:
 - name: timja
 - name: dduportal
 name: jenkinsio
-version: 1.1.3
+version: 1.2.0

--- a/charts/jenkinsio/templates/configmap.yaml
+++ b/charts/jenkinsio/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jenkinsioEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -110,3 +111,4 @@ data:
       rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;
       rewrite ^/iep/([0-9]+) https://github.com/jenkins-infra/iep/blob/master/iep/$1/README.adoc permanent;
     }
+{{- end }}

--- a/charts/jenkinsio/templates/deployment.yaml
+++ b/charts/jenkinsio/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jenkinsioEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,7 +14,7 @@ spec:
     metadata:
       labels: {{include "jenkinsio.labels" . | nindent 8}}
       annotations:
-        checksum/config: {{include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum}}
+        checksum/config: {{include (print $.Template.BasePath "/configmap.yaml") . | sha256sum}}
     spec:
       automountServiceAccountToken: false
     {{- with .Values.imagePullSecrets }}
@@ -75,3 +76,4 @@ spec:
         - name: config
           configMap:
             name: {{ include "jenkinsio.fullname" . }}
+{{- end }}

--- a/charts/jenkinsio/templates/pdb.yaml
+++ b/charts/jenkinsio/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jenkinsioEnabled }}
 {{- if (gt (int .Values.replicaCount) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "jenkinsio.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/jenkinsio/templates/secret.yaml
+++ b/charts/jenkinsio/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jenkinsioEnabled }}
 {{ if .Values.azureStorageAccountName }}
 ---
 apiVersion: v1
@@ -8,4 +9,5 @@ type: Opaque
 data:
   azurestorageaccountname: {{ .Values.azureStorageAccountName | b64enc }}
   azurestorageaccountkey: {{ .Values.azureStorageAccountKey | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/jenkinsio/templates/service.yaml
+++ b/charts/jenkinsio/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.jenkinsioEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "jenkinsio.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/jenkinsio/templates/zh-configmap.yaml
+++ b/charts/jenkinsio/templates/zh-configmap.yaml
@@ -1,4 +1,4 @@
-  
+{{- if .Values.zhJenkinsioEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,3 +42,4 @@ data:
           root   /usr/share/nginx/html;
       }
     }
+{{- end }}

--- a/charts/jenkinsio/templates/zh-deployment.yaml
+++ b/charts/jenkinsio/templates/zh-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.zhJenkinsioEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,4 +74,5 @@ spec:
 {{- end }}
         - name: config
           configMap:
-            name: {{ include "jenkinsio.fullname" . }}
+            name: {{ include "jenkinsio.fullname" . }}-zh
+{{- end }}

--- a/charts/jenkinsio/templates/zh-pdb.yaml
+++ b/charts/jenkinsio/templates/zh-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.zhJenkinsioEnabled }}
 {{- if (gt (int .Values.replicaCount) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -15,4 +16,5 @@ spec:
   selector:
     matchLabels:
       {{- include "jenkinsio-zh.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/jenkinsio/templates/zh-secret.yaml
+++ b/charts/jenkinsio/templates/zh-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.zhJenkinsioEnabled }}
+{{ if .Values.zhAzureStorageAccountName }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "jenkinsio.fullname" . }}-zh
+type: Opaque
+data:
+  azurestorageaccountname: {{ .Values.zhAzureStorageAccountName | b64enc }}
+  azurestorageaccountkey: {{ .Values.zhAzureStorageAccountKey | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/jenkinsio/templates/zh-service.yaml
+++ b/charts/jenkinsio/templates/zh-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.zhJenkinsioEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "jenkinsio.name" . }}-zh
     app.kubernetes.io/instance: {{ .Release.Name }}-zh
+{{- end }}

--- a/charts/jenkinsio/tests/custom_values_test.yaml
+++ b/charts/jenkinsio/tests/custom_values_test.yaml
@@ -2,10 +2,10 @@ suite: Test with custom values
 templates:
   - deployment.yaml
   - zh-deployment.yaml
+  - configmap.yaml
   - zh-configmap.yaml
-  - nginx-configmap.yaml
   - pdb.yaml
-  - pdb-zh.yaml
+  - zh-pdb.yaml
 set:
   htmlVolume:
     azureFile:
@@ -90,7 +90,7 @@ tests:
           path: metadata.labels["app.kubernetes.io/name"]
           value: jenkinsio
   - it: should ensure the pdb has correct spec for jenkinsio-zh
-    template: pdb-zh.yaml
+    template: zh-pdb.yaml
     set:
       replicaCount: 2
       poddisruptionbudget.jenkinsiozh.minAvailable: 3
@@ -110,3 +110,19 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: jenkinsio
+  - it: should not deploy jenkinsio if disabled
+    templates:
+      - deployment.yaml
+    set:
+      jenkinsioEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not deploy jenkinsio-zh if disabled
+    templates:
+      - zh-deployment.yaml
+    set:
+      zhJenkinsioEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/jenkinsio/tests/defaults_values_test.yaml
+++ b/charts/jenkinsio/tests/defaults_values_test.yaml
@@ -2,8 +2,8 @@ suite: Test with default values
 templates:
   - deployment.yaml
   - zh-deployment.yaml
+  - configmap.yaml
   - zh-configmap.yaml
-  - nginx-configmap.yaml
   - pdb.yaml
 tests:
   - it: should create a deployment for jenkins.io with default values

--- a/charts/jenkinsio/values.yaml
+++ b/charts/jenkinsio/values.yaml
@@ -53,6 +53,8 @@ affinity:
   jenkinsio-zh: {}
 htmlVolume: {}
 zhHtmlVolume: {}
+jenkinsioEnabled: true
+zhJenkinsioEnabled: true
 forceJenkinsIoHost: false
 poddisruptionbudget:
   jenkinsio:


### PR DESCRIPTION
This PR allows disabling the deployment of the international or the chinese version of the website.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1961011896
- https://github.com/jenkins-infra/helpdesk/issues/3379