### PR TITLE
feat!(artifact-caching-proxy) introduces repository fallbacks chain

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 0.16.1
+version: 1.0.0

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -7,12 +7,6 @@ data:
   cache.conf: |
     proxy_cache_path {{ .Values.cache.path }} levels=1 keys_zone=nginx_cache:{{ .Values.cache.keysZoneSize }} max_size={{ .Values.persistence.size }}g inactive={{ .Values.cache.inactive }} use_temp_path={{ .Values.cache.useTempPath }};
   common-proxy.conf: |
-    # Enable caching
-    proxy_cache         nginx_cache;
-
-    # Specify HTTP code of responses to cache
-    proxy_cache_valid {{ .Values.proxy.proxyCacheValidCode }} {{ .Values.proxy.proxyCacheValidCodeDuration }};
-
     # Ensure that no authentication header are sent to the upstreams
     proxy_set_header    Authorization     "";
 
@@ -28,8 +22,12 @@ data:
 
     # Remove any cookie in the requests to upstream
     proxy_cookie_path   ~*^/.* /;
+  proxy-cache.conf: |
+    # Enable caching
+    proxy_cache         nginx_cache;
 
-    proxy_read_timeout  900;
+    # Specify HTTP code of responses to cache
+    proxy_cache_valid {{ .Values.proxy.proxyCacheValidCode }} {{ .Values.proxy.proxyCacheValidCodeDuration }};
   vhost-proxy.conf: |
     include /etc/nginx/conf.d/cache.conf;
 
@@ -39,9 +37,11 @@ data:
 
         # Specify a DNS resolver to ensure upstream DNS are dynamically resolved
         # Ref. https://github.com/DmitryFillo/nginx-proxy-pitfalls
-        resolver 9.9.9.9 valid=60s;
-        # Specify the upstream URL as a variable to ensure dynamic resolution
-        set $remote_repo {{ .Values.proxy.proxyPass }};
+        # and disable IPv6 resolution to ensure only IPv4 hosts are used for upstreams
+        resolver 9.9.9.9 valid=60s ipv6=off;
+        # Specify the upstream URLs as a variables to ensure dynamic name resolution
+        set $jenkins_repo {{ .Values.proxy.proxyPass }};
+        set $central_repo repo1.maven.org;
 
         if ($http_x_forwarded_proto = '') {
             set $http_x_forwarded_proto  $scheme;
@@ -64,20 +64,83 @@ data:
         # Headers added to responses to the client
         add_header          X-Cache-Status    $upstream_cache_status;
 
-        # Location for the non-cached requests
+        # Allow chaining upstreams fallbacks (using proxy_intercept_errors + error_page) up to 10 redirects per request
+        # See http://nginx.org/en/docs/http/ngx_http_core_module.html#recursive_error_pages and http://nginx.org/en/docs/http/ngx_http_core_module.html#internal
+        recursive_error_pages on;
+
+        # Non-cached requests
+        ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
         location ~* (maven-metadata.xml) {
-            proxy_pass          https://$remote_repo$request_uri;
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            proxy_pass          https://$jenkins_repo/public$request_uri;
+
+            proxy_intercept_errors on;
+            # If the file is not found, then fallback the search in the "non-cached jenkins incrementals" upstream server
+            error_page 404 = @fallback_noncached_jenkins_incrementals;
+        }
+        location @fallback_noncached_jenkins_incrementals {
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            proxy_pass          https://$jenkins_repo/incrementals$request_uri;
+
+            proxy_intercept_errors on;
+            # If the file is not found, then fallback the search in the "non-cached maven central" upstream server
+            error_page 404 = @fallback_noncached_maven_central;
+        }
+        location @fallback_noncached_maven_central {
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            proxy_pass          https://$central_repo/maven2$request_uri;
+
+            # Stop chaining requests
+            proxy_intercept_errors off;
         }
 
-        # Default location for cached requests
+        # Cached requests
+        ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
         location / {
 {{- if .Values.proxy.proxyBypass.enabled -}}
             add_header Cache $upstream_cache_status;
             proxy_cache_bypass $bypass;
 {{- end }}
-            proxy_pass          https://$remote_repo$request_uri;
+            proxy_pass          https://$jenkins_repo/public$request_uri;
             proxy_cache_key     $uri;
-            include /etc/nginx/conf.d/common-proxy.conf;
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            include             /etc/nginx/conf.d/proxy-cache.conf;
+
+            proxy_intercept_errors on;
+            # If the file is not found, then fallback the search in the "jenkins incrementals" upstream server
+            error_page 404 = @fallback_jenkins_incrementals;
+            # If upstream respond with "HTTP 30x Redirect" then Nginx must re-emit a proxy request to the new location (see location @handle_redirects)
+            error_page 307 302 301 = @handle_redirects;
+        }
+
+        ## Fallback location to "jenkins incrementals" repository
+        location @fallback_jenkins_incrementals {
+{{- if .Values.proxy.proxyBypass.enabled -}}
+            add_header Cache $upstream_cache_status;
+            proxy_cache_bypass $bypass;
+{{- end }}
+            proxy_pass          https://$jenkins_repo/incrementals$request_uri;
+            proxy_cache_key     $uri;
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            include             /etc/nginx/conf.d/proxy-cache.conf;
+
+            proxy_intercept_errors on;
+            # If the file is not found, then fallback the search in the "maven central" upstream server
+            error_page 404 = @fallback_maven_central;
+            # If upstream respond with "HTTP 30x Redirect" then Nginx must re-emit a proxy request to the new location (see location @handle_redirects)
+            error_page 307 302 301 = @handle_redirects;
+        }
+
+        ## Fallback location to maven central
+        location @fallback_maven_central {
+{{- if .Values.proxy.proxyBypass.enabled -}}
+            add_header Cache $upstream_cache_status;
+            proxy_cache_bypass $bypass;
+{{- end }}
+            proxy_pass          https://$central_repo/maven2$request_uri;
+            proxy_cache_key     $uri;
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            include             /etc/nginx/conf.d/proxy-cache.conf;
 
             # If upstream respond with "HTTP 30x Redirect"
             # then this section will be used to follow the redirect

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -25,6 +25,12 @@ tests:
       - isKind:
           of: ConfigMap
       - isNotNullOrEmpty:
+          path: data["cache.conf"]
+      - isNotNullOrEmpty:
+          path: data["common-proxy.conf"]
+      - isNotNullOrEmpty:
+          path: data["proxy-cache.conf"]
+      - isNotNullOrEmpty:
           path: data["vhost-proxy.conf"]
       - isNotNullOrEmpty:
           path: data["vhost-status.conf"]

--- a/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
+++ b/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
@@ -1,0 +1,49 @@
+suite: Tests using proxy_cache setups
+templates:
+  - nginx-proxy-configmap.yaml
+tests:
+  - it: Should include set proxy_cache with default setup
+    template: nginx-proxy-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["cache.conf"]
+          pattern: proxy_cache_path /data/nginx-cache levels=1 keys_zone=nginx_cache:200m max_size=50g inactive=1M use_temp_path=off;
+      - matchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_cache         nginx_cache;
+      - matchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_cache_valid 200 206 1M;
+  - it: Should include set proxy_cache with default setup
+    template: nginx-proxy-configmap.yaml
+    set:
+      cache:
+        path: /CACHE
+        keysZoneSize: "500m"
+        inactive: "2H"
+        useTempPath: "on"
+      persistence:
+        enabled: true
+        size: 200
+      proxy:
+        proxyPass: "repo.jenkins-ci.org"
+        proxyCacheValidCode: "201 204"
+        proxyCacheValidCodeDuration: "3H"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["cache.conf"]
+          pattern: proxy_cache_path /CACHE levels=1 keys_zone=nginx_cache:500m max_size=200g inactive=2H use_temp_path=on;
+      - matchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_cache         nginx_cache;
+      - matchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_cache_valid 201 204 3H;


### PR DESCRIPTION
The goal is to improve build performances by:

- Caching Maven central artifacts in ACP along with Jenkins artefacts
- Delegate the chain of "retries" to Nginx (instead of Maven) for efficient caching
- Tune the network behavior by disabling IPv6 DNS resolution and using default Nginx timeouts

The fallback setup is defined statically in the ConfigMap. Possible improvement would be to templatize the chain of fallbacks. For this version the chain is the following: "Jenkins public repo" -> "Jenkins incrementals repo" -> "Maven Central repo".

Notes:

- The number of possible fallbacks is limited internally in Nginx to 10 (ref. http://nginx.org/en/docs/http/ngx_http_core_module.html#recursive_error_pages)
- The non-cached requests (maven-metadata.xml files) are also chained on their own using the same (Possible improvement by templatizing)

BREAKING CHANGE: For each `mirror.url`attribute in the `~/.m2/settings.xml` pointing to ACP, there should be no URI (path) otherwise ACP will answer HTTP/404.
  Example: `<url>http://localhost:8888/</url>` instead of `<url>http://localhost:8888/public/</url>`.