### PR TITLE
feat(artifact-caching-proxy) tune proxy upstream buffering and enable gzip with upstream

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.0.0
+version: 1.1.0

--- a/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-default-configmap.yaml
@@ -41,6 +41,12 @@ data:
         directio            10m;
         directio_alignment 4096;
 
+        # Tune proxy buffering to ensure large files are handled
+        # Inspired by https://jfrog.com/help/r/artifactory-how-to-enable-tls-within-the-jfrog-platform/artifactory-nginx-configuration
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
+
         keepalive_timeout  65;
 
         gzip  on;

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -22,6 +22,12 @@ data:
 
     # Remove any cookie in the requests to upstream
     proxy_cookie_path   ~*^/.* /;
+
+    # Compress request/respons with upstream
+    # Requires '--with-http_gunzip_module' in 'nginx -V'
+    gunzip on;
+    proxy_set_header Accept-Encoding "gzip";
+    gzip_proxied any;
   proxy-cache.conf: |
     # Enable caching
     proxy_cache         nginx_cache;


### PR DESCRIPTION
This change is motivated by https://github.com/jenkins-infra/helpdesk/issues/3969#issuecomment-2027356553. The goal is to decrease or remove the warning messages:

```
an upstream response is buffered to a temporary file /var/cache/nginx/proxy_temp/<...> while reading upstream
````

It includes the 2 following elements:

- Increasing the proxy buffer size given the size of the files served by ACP. It maps to JFrog Artifactory recommended settings (https://jfrog.com/help/r/artifactory-how-to-enable-tls-within-the-jfrog-platform/artifactory-nginx-configuration).
    - Note: This will increase memory usage but the ACP metrics shows than there is enough memory to handle this change

- Enable gzip for requests with the upstream to decrease the size of in-memory required buffers of responses - Note: This will increase CPU usage but the ACP metrics shows that CPU is doing almost nothing.