### PR TITLE
chore(httpd): remove unused `conf` value

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.3.2
+version: 0.3.3
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -71,11 +71,6 @@ repository:
     enabled: false
     # data hold secrets data used by persistentVolume
     data: {}
-# httpd.conf data, to be completed as secret with Redis credentials
-conf: |
-  Repository: /srv/repo
-  Templates: /usr/share/mirrorbits/templates
-  RedisAddress: mirrors-redis-master:6379
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
This PR removes a remnant configuration from #641 that should have been deleted in #667.

I'm preparing another PR to be able to properly set httpd conf via chart values.

Follow-up of:
- #641 
- #667 