### PR TITLE
fix(mirrorbits-parent): correct ingress custom test

### DIFF
--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 2.0.22
+version: 2.0.23
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
@@ -128,7 +128,7 @@ tests:
                 - path: /
     asserts:
       - failedTemplate:
-          errorMessage: "Required key: backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'."
+          errorMessage: "backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'."
   - it: should fail the ingress when a host's path has an unknown backendService
     template: ingress.yaml
     set:
@@ -141,7 +141,7 @@ tests:
                   backendService: yipikai
     asserts:
       - failedTemplate:
-          errorMessage: "Required key: backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'."
+          errorMessage: "backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'."
   - it: should fail the ingress when referencing httpd as backend but it is disabled
     template: ingress.yaml
     set:


### PR DESCRIPTION
This PR fixes mirrorbits-parent's ingress custom test.

No idea yet why this passed our pipelines without failing 🤔 

<details><summary>Before:</summary>

```console
✗ helm unittest  charts/mirrorbits-parent

### Chart [ mirrorbits-parent ] charts/mirrorbits-parent

 FAIL  Tests with custom values charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
        - should fail the ingress when a host's path does not have backendService

                - asserts[0] `failedTemplate` fail
                        Template:       mirrorbits-parent/templates/ingress.yaml
                        DocumentIndex:  0
                        Expected to equal:
                                Required key: backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'.
                        Actual:
                                backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'.

        - should fail the ingress when a host's path has an unknown backendService

                - asserts[0] `failedTemplate` fail
                        Template:       mirrorbits-parent/templates/ingress.yaml
                        DocumentIndex:  0
                        Expected to equal:
                                Required key: backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'.
                        Actual:
                                backendService for ingress.hosts[].paths[] objects must have the value 'httpd' or 'mirrorbits'.

 PASS  Tests with custom values charts/mirrorbits-parent/tests/custom_values_serviceaccount_test.yaml
 PASS  Tests with custom values charts/mirrorbits-parent/tests/custom_values_storage_test.yaml
 PASS  tests for the storager with defaults     charts/mirrorbits-parent/tests/defaults_storage_test.yaml
 PASS  default tests    charts/mirrorbits-parent/tests/defaults_test.yaml

Charts:      1 failed, 0 passed, 1 total
Test Suites: 1 failed, 4 passed, 5 total
Tests:       2 failed, 17 passed, 19 total
Snapshot:    0 passed, 0 total
Time:        43.717625ms

Error: plugin "unittest" exited with error
```

</details>
