### PR TITLE
cleanup(jenkins-jobs) remove references to cik8s deleted cluster

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.6.0
+version: 0.6.1
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -33,10 +33,10 @@ tests:
               username: ${SSH_CHARTS_SECRETS_USERNAME}
               description: "SSH privkey used to access jenkins-infra/charts-secrets"
               privateKey: "${SSH_CHARTS_SECRETS_PRIVKEY}"
-            kubeconfig-cik8s:
+            kubeconfig-cluster-1:
               fileName: "kubeconfig"
-              description: "Kubeconfig file for cik8s"
-              secretBytes: "${base64:${KUBECONFIG_CIK8S}}"
+              description: "Kubeconfig file for cluster-1"
+              secretBytes: "${base64:${KUBECONFIG_CLUSTER-1}}"
             bot-github-app:
               appId: "${GITHUB_APP_BOT_APPID}"
               privateKey: "${GITHUB_APP_BOT_KEY}"
@@ -145,10 +145,10 @@ tests:
 
                       configNode << 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl' {
                         scope('GLOBAL')
-                        id('kubeconfig-cik8s')
-                        description('Kubeconfig file for cik8s')
+                        id('kubeconfig-cluster-1')
+                        description('Kubeconfig file for cluster-1')
                         fileName('kubeconfig')
-                        secretBytes(com.cloudbees.plugins.credentials.SecretBytes.fromBytes(new String('${base64:${KUBECONFIG_CIK8S}}').decodeBase64()).toString())
+                        secretBytes(com.cloudbees.plugins.credentials.SecretBytes.fromBytes(new String('${base64:${KUBECONFIG_CLUSTER-1}}').decodeBase64()).toString())
                       }
                       configNode << 'com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey' {
                         scope('GLOBAL')

--- a/charts/jenkins-jobs/values.yaml
+++ b/charts/jenkins-jobs/values.yaml
@@ -40,7 +40,7 @@ jobsDefinition: {}
 #              username: ${SSH_CHARTS_SECRETS_USERNAME}
 #              description: "SSH privkey used to access jenkins-infra/charts-secrets"
 #              privateKey: "${SSH_CHARTS_SECRETS_PRIVKEY}"
-#            kubeconfig-cik8s:
+#            kubeconfig-cluster-1:
 #              fileName: "kubeconfig"
-#              description: "Kubeconfig file for cik8s"
-#              secretBytes: "${base64:${KUBECONFIG_CIK8S}}"
+#              description: "Kubeconfig file for cluster-1"
+#              secretBytes: "${base64:${KUBECONFIG_CLUSTER_1}}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954

This PR is a non-functional change to remove references to the deleted EKS cluster `cik8s`.

Note these references where only comments or tests.