### PR TITLE
make first proxy target path configurable

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.1.2
+version: 1.1.4

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -48,6 +48,7 @@ data:
         # Specify the upstream URLs as a variables to ensure dynamic name resolution
         set $jenkins_repo {{ .Values.proxy.proxyPass }};
         set $central_repo repo1.maven.org;
+        set $initial_proxy_location {{ .Values.proxy.initialProxyLocationPath }};
 
         if ($http_x_forwarded_proto = '') {
             set $http_x_forwarded_proto  $scheme;
@@ -78,7 +79,7 @@ data:
         ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
         location ~* (maven-metadata.xml) {
             include             /etc/nginx/conf.d/common-proxy.conf;
-            proxy_pass          https://$jenkins_repo/public$request_uri;
+            proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
 
             proxy_intercept_errors on;
             # If the file is not found, then fallback the search in the "non-cached jenkins incrementals" upstream server
@@ -107,7 +108,7 @@ data:
             add_header Cache $upstream_cache_status;
             proxy_cache_bypass $bypass;
 {{- end }}
-            proxy_pass          https://$jenkins_repo/public$request_uri;
+            proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
             proxy_cache_key     $uri;
             include             /etc/nginx/conf.d/common-proxy.conf;
             include             /etc/nginx/conf.d/proxy-cache.conf;

--- a/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
+++ b/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
@@ -18,6 +18,10 @@ tests:
       - matchRegex:
           path: data["proxy-cache.conf"]
           pattern: proxy_cache_valid 200 206 1M;
+      - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: set \$initial_proxy_location /public;
+
   - it: Should include set proxy_cache with default setup
     template: nginx-proxy-configmap.yaml
     set:
@@ -33,6 +37,7 @@ tests:
         proxyPass: "repo.jenkins-ci.org"
         proxyCacheValidCode: "201 204"
         proxyCacheValidCodeDuration: "3H"
+        initialProxyLocationPath: /
     asserts:
       - hasDocuments:
           count: 1
@@ -47,3 +52,6 @@ tests:
       - matchRegex:
           path: data["proxy-cache.conf"]
           pattern: proxy_cache_valid 201 204 3H;
+      - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: set \$initial_proxy_location /;

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -85,6 +85,8 @@ proxy:
   # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_bypass
   proxyBypass:
     enabled: false
+  # Allows the configuration of the initial proxy location (e.g. setting to '/' will proxy all requests to the upstream)
+  initialProxyLocationPath: /public
 poddisruptionbudget:
   minAvailable: 1
 env: []


### PR DESCRIPTION
This PR makes the initial proxy location path configurable.

The chart version has been set, anticipating #1168 being merged first.
