### PR TITLE
make dns resolver configurable

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.3.0
+version: 1.4.0

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -44,7 +44,7 @@ data:
         # Specify a DNS resolver to ensure upstream DNS are dynamically resolved
         # Ref. https://github.com/DmitryFillo/nginx-proxy-pitfalls
         # and disable IPv6 resolution to ensure only IPv4 hosts are used for upstreams
-        resolver 9.9.9.9 valid=60s ipv6=off;
+        resolver {{ .Values.proxy.dnsResolver }} valid=60s ipv6=off;
         # Specify the upstream URLs as a variables to ensure dynamic name resolution
         set $jenkins_repo {{ .Values.proxy.proxyPass }};
         set $central_repo repo1.maven.org;

--- a/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
+++ b/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
@@ -22,6 +22,9 @@ tests:
           path: data["vhost-proxy.conf"]
           pattern: set \$initial_proxy_location /public;
       - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: resolver 9.9.9.9 valid=60s ipv6=off;
+      - matchRegex:
           path: data["common-proxy.conf"]
           pattern: proxy_set_header    Authorization     "";
   - it: Should include set proxy_cache with default setup
@@ -41,6 +44,7 @@ tests:
         proxyCacheValidCodeDuration: "3H"
         initialProxyLocationPath: /
         authorizationHeader: "Bearer 123456"
+        dnsResolver: 8.8.8.8
     asserts:
       - hasDocuments:
           count: 1
@@ -58,6 +62,9 @@ tests:
       - matchRegex:
           path: data["vhost-proxy.conf"]
           pattern: set \$initial_proxy_location /;
+      - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: resolver 8.8.8.8 valid=60s ipv6=off;
       - matchRegex:
           path: data["common-proxy.conf"]
           pattern: proxy_set_header    Authorization     "Bearer 123456";

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -89,6 +89,8 @@ proxy:
   initialProxyLocationPath: /public
   # Allows to set the Authorization header to be sent to the upstream, e.g. "Bearer 123"
   authorizationHeader: ""
+  # Allows to set the DNS resolver to be used for upstreams
+  dnsResolver: 9.9.9.9
 poddisruptionbudget:
   minAvailable: 1
 env: []


### PR DESCRIPTION
This PR makes the dns resolver IP configurable since some people have their own DNS servers.

- Allow configuration of dns resolver
- Bump chart version for new feature
