### PR TITLE
Make initial regex configurable

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.4.1
+version: 1.5.1

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -77,7 +77,7 @@ data:
 
         # Non-cached requests
         ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
-        location ~* (maven-metadata.xml) {
+        location ~* ({{ .Values.proxy.initialProxyLocationRegex }}) {
             include             /etc/nginx/conf.d/common-proxy.conf;
             proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
 

--- a/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
+++ b/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
@@ -25,6 +25,9 @@ tests:
           path: data["vhost-proxy.conf"]
           pattern: resolver 9.9.9.9 valid=60s ipv6=off;
       - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: location ~\* \(maven-metadata.xml\) {
+      - matchRegex:
           path: data["common-proxy.conf"]
           pattern: proxy_set_header    Authorization     "";
   - it: Should include set proxy_cache with default setup
@@ -42,7 +45,8 @@ tests:
         proxyPass: "repo.jenkins-ci.org"
         proxyCacheValidCode: "201 204"
         proxyCacheValidCodeDuration: "3H"
-        initialProxyLocationPath: /
+        initialProxyLocationPath: '""'
+        initialProxyLocationRegex: pi$
         authorizationHeader: "Bearer 123456"
         dnsResolver: 8.8.8.8
     asserts:
@@ -61,7 +65,10 @@ tests:
           pattern: proxy_cache_valid 201 204 3H;
       - matchRegex:
           path: data["vhost-proxy.conf"]
-          pattern: set \$initial_proxy_location /;
+          pattern: set \$initial_proxy_location "";
+      - matchRegex:
+          path: data["vhost-proxy.conf"]
+          pattern: location ~\* \(pi\$\) {
       - matchRegex:
           path: data["vhost-proxy.conf"]
           pattern: resolver 8.8.8.8 valid=60s ipv6=off;

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -87,6 +87,8 @@ proxy:
     enabled: false
   # Allows the configuration of the initial proxy location (e.g. setting to '/' will proxy all requests to the upstream)
   initialProxyLocationPath: /public
+  # Allows the configuration of the initial proxy location regex (e.g. setting to 'pi$' will proxy all *.hpi or *.jpi to the upstream)
+  initialProxyLocationRegex: maven-metadata.xml
   # Allows to set the Authorization header to be sent to the upstream, e.g. "Bearer 123"
   authorizationHeader: ""
   # Allows to set the DNS resolver to be used for upstreams


### PR DESCRIPTION
This PR makes the initial location regex configurable so as to allow people to use it for proxying other things such as plugins (hpi and jpi files).