### PR TITLE
feat(jenkins-jobs): allow defining excluded branch pattern

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 0.6.1
+version: 0.7.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -166,7 +166,7 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
             // Select branches and tags to build based on these filters
             headWildcardFilterWithPR {
               includes('{{ .branchIncludes | default "main master PR-*" }}') // only branches listed here
-              excludes('')
+              excludes('{{ .branchExcludes | default "" }}')
               tagIncludes('*')
               tagExcludes('')
             }

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -355,6 +355,7 @@ tests:
           allowUntrustedChanges: true
           jenkinsfilePath: Jenkinsfile
           branchIncludes: "prod dev MR-*"
+          branchExcludes: "excluded"
           disableTagDiscovery: true
     asserts:
       - equal:
@@ -410,7 +411,7 @@ tests:
                               // Select branches and tags to build based on these filters
                               headWildcardFilterWithPR {
                                 includes('prod dev MR-*') // only branches listed here
-                                excludes('')
+                                excludes('excluded')
                                 tagIncludes('*')
                                 tagExcludes('')
                               }

--- a/charts/jenkins-jobs/values.yaml
+++ b/charts/jenkins-jobs/values.yaml
@@ -35,6 +35,7 @@ jobsDefinition: {}
 #          allowUntrustedChanges: true
 #          jenkinsfilePath: Jenkinsfile
 #          branchIncludes: "prod dev MR-*"
+#          branchExcludes: "excluded"
 #         credentials:
 #            ssh-deploy-key:
 #              username: ${SSH_CHARTS_SECRETS_USERNAME}


### PR DESCRIPTION
This PR allows configuring excluded branch pattern for jobs.

Example of use-case: not running pipeline dedicated to PR previews on primary branch.

Ref:
- https://github.com/jenkins-infra/kubernetes-management/pull/5345