### PR TITLE
feat(artifact-caching-proxy) allow customization of the PVC template prefix (for statefulset)

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.4.1
+version: 1.5.0

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -129,9 +129,11 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: nginx-cache
+      name: {{ .Values.persistence.claimPrefix }}
     spec:
-      storageClassName: {{ .Values.persistence.storageClass }}
+      {{- with .Values.persistence.storageClass }}
+      storageClassName: {{ . }}
+      {{- end }}
       accessModes:
       - {{ .Values.persistence.accessMode }}
       resources:

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -42,6 +42,12 @@ tests:
           cpu: 500m
         requests:
           memory: 1024Mi
+      persistence:
+        enabled: true
+        storageClass: x-wing
+        claimPrefix: wookie
+        existingVolumeName: death-star
+        accessMode: ReadManyWrite
     asserts:
       - hasDocuments:
           count: 1
@@ -83,6 +89,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 1024Mi
+      - notExists:
+          path: spec.template.spec.volumes[3]
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: wookie
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: x-wing
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.accessModes[0]
+          value: ReadManyWrite
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 50Gi
   - it: Should set a custom health check path when specified by values
     template: ingress.yaml
     set:

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -70,6 +70,11 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: nginx-cache
+      - exists:
+          path: spec.template.spec.volumes[3].emptyDir
   - it: should not generate any pdb with default values
     template: pdb.yaml
     asserts:

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -66,6 +66,7 @@ auth:
   basicAuth: ""
 persistence:
   enabled: false
+  claimPrefix: nginx-cache
   # cache size (in gigabyte)
   size: 50
   storageClass: ""


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3837, we've been stucked with specifying existing PV for the ACP statefulset.

See https://github.com/jenkins-infra/azure/pull/775#issuecomment-2210796493

As per https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/preexisting-pd#pv_to_statefulset, we can determine the name of the PVCs in advance so we can specify the binding PV <-> PVC on the PV side (in Terraform) using the `claimRef` attribute.

As such, this PR allows customizing the prefix used by Statefulset to generate the PVC names.

Tested against production with the following `helmfile diff`:

```diff
 persistence:
-  storageClass: managed-csi-premium-retain
+  enabled: true
+  size: 32
+  storageClass: statically-provisionned
+  # Deterministic name - https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/preexisting-pd#pv_to_statefulset
+  # to ensure the Terraform-managed PV can specify `claimRef`with the full generated name
+  claimPrefix: data
```

```diff
    volumeClaimTemplates:
    - metadata:
-       name: nginx-cache
+       name: data
      spec:
-       storageClassName: managed-csi-premium-retain
+       storageClassName: statically-provisionned
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
-           storage: "100Gi"
+           storage: "32Gi"
```