### PR TITLE
feat(ldap) allow specifying custom PVC for data or backup volumes

### DIFF
--- a/charts/ldap/Chart.yaml
+++ b/charts/ldap/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for ldap.jenkins.io
 maintainers:
 - name: jenkins-infra-team@googlegroups.com
 name: ldap
-version: 1.0.3
+version: 1.1.0

--- a/charts/ldap/templates/persistentVolume.yaml
+++ b/charts/ldap/templates/persistentVolume.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.persistence.customBackupClaimName }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -18,3 +20,4 @@ spec:
     secretNamespace: {{ .Release.Namespace }}
     shareName: ldap
     readOnly: false
+{{- end }}

--- a/charts/ldap/templates/persistentVolumeClaim.yaml
+++ b/charts/ldap/templates/persistentVolumeClaim.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.customBackupClaimName }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -13,6 +14,8 @@ spec:
   selector:
     matchLabels:
       role: ldap-backup
+{{- end }}
+{{- if not .Values.persistence.customDataClaimName }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,4 +27,4 @@ spec:
   resources:
     requests:
       storage: 50Gi
-
+{{- end }}

--- a/charts/ldap/templates/statefulset.yaml
+++ b/charts/ldap/templates/statefulset.yaml
@@ -118,10 +118,10 @@ spec:
       volumes:
         - name: backup
           persistentVolumeClaim:
-            claimName: {{ include "ldap.fullname" . }}-backup
+            claimName: {{ default (printf "%s-backup" (include "ldap.fullname" .)) .Values.persistence.customBackupClaimName }}
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "ldap.fullname" . }}-data
+            claimName: {{ default (printf "%s-data" (include "ldap.fullname" .)) .Values.persistence.customDataClaimName }}
         - name: tls
           secret:
             secretName: ldap-tls

--- a/charts/ldap/tests/custom_values_test.yaml
+++ b/charts/ldap/tests/custom_values_test.yaml
@@ -2,6 +2,9 @@ suite: Test with custom values
 templates:
   - secret.yaml
   - service.yaml
+  - statefulset.yaml
+  - persistentVolumeClaim.yaml
+  - persistentVolume.yaml
 tests:
   - it: should create a Secret with the correct value
     set:
@@ -80,3 +83,44 @@ tests:
     - equal:
         path: metadata.annotations["service.beta.kubernetes.io/azure-pip-name"]
         value: myAKSPublicIP
+  - it: should create a statefulset with custom settings
+    template: statefulset.yaml
+    set:
+      persistence:
+        customBackupClaimName: superBackup
+        customDataClaimName: batData
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: StatefulSet
+    - equal:
+        path: spec.template.spec.volumes[0].name
+        value: backup
+    - equal:
+        path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+        value: superBackup
+    - equal:
+        path: spec.template.spec.volumes[1].name
+        value: data
+    - equal:
+        path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+        value: batData
+  - it: should not create any PVs or PVCs when specifying custom claim names
+    template: persistentVolumeClaim.yaml
+    set:
+      persistence:
+        customBackupClaimName: superBackup
+        customDataClaimName: batData
+    asserts:
+    - hasDocuments:
+        count: 0
+  - it: should not create any PV when specifying custom claim names
+    template: persistentVolume.yaml
+    set:
+      persistence:
+        customBackupClaimName: superBackup
+        customDataClaimName: batData
+    asserts:
+    - hasDocuments:
+        count: 0

--- a/charts/ldap/tests/defaults_values_test.yaml
+++ b/charts/ldap/tests/defaults_values_test.yaml
@@ -1,8 +1,10 @@
 suite: Test with default values
 templates:
   - certificate.yaml
+  - persistentVolume.yaml
   - persistentVolumeClaim.yaml
   - service.yaml
+  - statefulset.yaml
 tests:
   - it: should create a certificate for the dns ldap.jenkins.io
     template: certificate.yaml
@@ -26,9 +28,6 @@ tests:
     - isKind:
         of: PersistentVolumeClaim
       documentIndex: 1
-  - it: should create 1 PVC for backup
-    template: persistentVolumeClaim.yaml
-    asserts:
     - equal:
         path: spec.selector.matchLabels.role
         value: ldap-backup
@@ -37,13 +36,20 @@ tests:
         path: metadata.name
         value: RELEASE-NAME-ldap-backup
       documentIndex: 0
-  - it: should create 1 PVC for data
-    template: persistentVolumeClaim.yaml
-    asserts:
     - equal:
         path: metadata.name
         value: RELEASE-NAME-ldap-data
       documentIndex: 1
+  - it: should create 1 PV for backup
+    template: persistentVolume.yaml
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: PersistentVolume
+    - equal:
+        path: metadata.name
+        value: RELEASE-NAME-ldap-backup
   - it: should create a service of type loadbalancer with defaults
     template: service.yaml
     asserts:
@@ -73,4 +79,25 @@ tests:
         path: spec.loadBalancerIP
     - notExists:
         path: metadata.annotations
-
+  - it: should create a statefulset with default settings
+    template: statefulset.yaml
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: StatefulSet
+    - equal:
+        path: spec.template.spec.volumes[0].name
+        value: backup
+    - equal:
+        path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+        value: RELEASE-NAME-ldap-backup
+    - equal:
+        path: spec.template.spec.volumes[1].name
+        value: data
+    - equal:
+        path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+        value: RELEASE-NAME-ldap-data
+    - equal:
+        path: spec.template.spec.volumes[2].name
+        value: tls

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -67,3 +67,8 @@ tolerations: []
 affinity: {}
 dnsNames:
   - ldap.jenkins.io
+persistence:
+  ## Uncomment to specify an existing PVC for backups
+  customBackupClaimName: ""
+  ## Uncomment to specify an existing PVC for data
+  customDataClaimName: ""


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3837

This PR introduces ability to specify custom PVCs for data and backup volumes