### PR TITLE
fix(acp) correct missing references to templatized volume in volumeMounts

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.5.0
+version: 1.5.1

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -115,7 +115,7 @@ spec:
           mountPath: /etc/nginx/conf.d/
         - name: nginx-tmp
           mountPath: /var/tmp/
-        - name: nginx-cache
+        - name: {{ .Values.persistence.claimPrefix }}
           mountPath: {{ .Values.cache.path }}
       volumes:
       - name: nginx-default-config
@@ -140,6 +140,6 @@ spec:
         requests:
           storage: "{{ .Values.persistence.size }}Gi"
   {{- else }}
-      - name: nginx-cache
+      - name: {{ .Values.persistence.claimPrefix }}
         emptyDir: {}
   {{- end }}

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -103,6 +103,9 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: 50Gi
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: wookie
   - it: Should set a custom health check path when specified by values
     template: ingress.yaml
     set:

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -75,6 +75,9 @@ tests:
           value: nginx-cache
       - exists:
           path: spec.template.spec.volumes[3].emptyDir
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: nginx-cache
   - it: should not generate any pdb with default values
     template: pdb.yaml
     asserts:


### PR DESCRIPTION
Fix errors like 

```
Warning  FailedCreate      2m11s (x27 over 29m)  statefulset-controller  create Pod artifact-caching-proxy-0 in StatefulSet artifact-caching-proxy failed error: Pod "artifact-caching-proxy-0" is invalid: [spec.containers[0].volumeMounts[3].name: Not found: "nginx-cache", spec.initContainers[0].volumeMounts[0].name: Not found: "nginx-cache"]
```