### PR TITLE
feat!(httpd) allow specifying a custom ServerName through the `httpdConf.serverName` new value.

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 0.4.2
+version: 1.0.0
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "httpd.fullname" . }}
 data:
   httpd.conf: |
-{{- if .Values.httpdConf }}
-{{- .Values.httpdConf | nindent 4 }}
+{{- if .Values.httpdConf.override }}
+{{- .Values.httpdConf.override | nindent 4 }}
 {{- else }}
     # Security
     ServerTokens Prod
@@ -203,6 +203,9 @@ data:
     # If your host doesn't have a registered DNS name, enter its IP address here.
     #
     #ServerName www.example.com:80
+    {{- with .Values.httpdConf.serverName }}
+    ServerName {{ . }}
+    {{- end }}
 
     #
     # Deny access to the entirety of your server's filesystem. You must

--- a/charts/httpd/tests/custom_values_test.yaml
+++ b/charts/httpd/tests/custom_values_test.yaml
@@ -19,8 +19,6 @@ set:
         paths:
         - path: /
           pathType: IfNotPresent
-  httpdConf: |
-    ServerName example.com
 tests:
   - it: Should set the correct service selector labels when a fullNameOverride is specified
     template: service.yaml
@@ -140,8 +138,14 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].pathType
           value: "IfNotPresent"
-  - it: should create a config map with custom httpd conf
+  - it: should create a config map with custom (overridden) httpd conf
     template: configmap.yaml
+    set:
+      httpdConf:
+        override: |
+          ServerName example.com
+        # The following line should be ignored as per the override
+        serverName: https://death.star:8443
     asserts:
       - hasDocuments:
           count: 1
@@ -151,3 +155,20 @@ tests:
           path: data["httpd.conf"]
           value: |
             ServerName example.com
+  - it: should create a config map with custom ServerName from values
+    template: configmap.yaml
+    set:
+      httpdConf:
+        serverName: https://death.star:8443
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notEqual:
+          path: data["httpd.conf"]
+          value: |
+            ServerName https://death.star:8443
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "ServerName https://death.star:8443"

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -71,8 +71,11 @@ repository:
     enabled: false
     # data hold secrets data used by persistentVolume
     data: {}
-# To override the default httpd.conf data tailored for mirrorbits, set the following value
-httpdConf: {}
+httpdConf:
+  # Overrides the default httpd.conf data with this multi-line string
+  override: ""
+  # Provides a custom ServerName directive
+  serverName: ""
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2255522243

BREAKING CHANGE: The `httpdConf` value is replaced by the `httpdConf.override` value.