### PR TITLE
feat!(jenkins-jobs) defaults Multibranch Jobs to remove orphaned items immediately and abord their builds.

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 1.0.0
+version: 2.0.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -205,11 +205,11 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
     }
   }
   orphanedItemStrategy {
-    // Remove unused items as soon as possible
-    discardOldItems {
-      // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-      // Does not apply to the build history of kept branches(use Pipeline for that)
-      daysToKeep(1)
+    defaultOrphanedItemStrategy {
+      pruneDeadBranches(true)
+      daysToKeepStr("{{ .orphanedItemStrategyDaysToKeep | default "" }}")
+      numToKeepStr("{{ .orphanedItemStrategyNumToKeep | default "" }}")
+      abortBuilds(true)
     }
   }
   configure { node ->

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -171,11 +171,11 @@ tests:
                       }
                     }
                     orphanedItemStrategy {
-                      // Remove unused items as soon as possible
-                      discardOldItems {
-                        // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-                        // Does not apply to the build history of kept branches(use Pipeline for that)
-                        daysToKeep(1)
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
                       }
                     }
                     configure { node ->

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -101,11 +101,11 @@ tests:
                       }
                     }
                     orphanedItemStrategy {
-                      // Remove unused items as soon as possible
-                      discardOldItems {
-                        // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-                        // Does not apply to the build history of kept branches(use Pipeline for that)
-                        daysToKeep(1)
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
                       }
                     }
                     configure { node ->
@@ -214,11 +214,11 @@ tests:
                       }
                     }
                     orphanedItemStrategy {
-                      // Remove unused items as soon as possible
-                      discardOldItems {
-                        // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-                        // Does not apply to the build history of kept branches(use Pipeline for that)
-                        daysToKeep(1)
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
                       }
                     }
                     configure { node ->
@@ -329,11 +329,11 @@ tests:
                       }
                     }
                     orphanedItemStrategy {
-                      // Remove unused items as soon as possible
-                      discardOldItems {
-                        // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-                        // Does not apply to the build history of kept branches(use Pipeline for that)
-                        daysToKeep(1)
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
                       }
                     }
                     configure { node ->
@@ -361,6 +361,8 @@ tests:
           branchExcludes: "excluded"
           disableTagDiscovery: true
           buildOnFirstIndexing: true
+          orphanedItemStrategyDaysToKeep: 3
+          orphanedItemStrategyNumToKeep: 10
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
@@ -441,11 +443,11 @@ tests:
                       }
                     }
                     orphanedItemStrategy {
-                      // Remove unused items as soon as possible
-                      discardOldItems {
-                        // Keep removed SCM heads/branch/PRs only for 1 day (not 0 days to be sure that jobs are all finished/timeouted when deleting)
-                        // Does not apply to the build history of kept branches(use Pipeline for that)
-                        daysToKeep(1)
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("3")
+                        numToKeepStr("10")
+                        abortBuilds(true)
                       }
                     }
                     configure { node ->


### PR DESCRIPTION
BREAKING CHANGE: Unless you specify a custom retention policy with the `orphanedItemStrategyDaysToKeep` and `orphanedItemStrategyNumToKeep`, the orphaned items will be disposed as soon as scanning detects the reference is gone.