### PR TITLE
feat(acp) allow specifying annotations for ACP Service

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.5.2
+version: 1.6.0

--- a/charts/artifact-caching-proxy/templates/service.yaml
+++ b/charts/artifact-caching-proxy/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "artifact-caching-proxy.fullname" . }}
   labels:
     {{- include "artifact-caching-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/artifact-caching-proxy/tests/custom_values_test.yaml
+++ b/charts/artifact-caching-proxy/tests/custom_values_test.yaml
@@ -6,6 +6,7 @@ templates:
   - statefulset.yaml
   - nginx-default-configmap.yaml
   - nginx-proxy-configmap.yaml
+  - service.yaml
 tests:
   - it: Should set a custom env and envFrom when specified by values
     template: statefulset.yaml
@@ -187,3 +188,35 @@ tests:
       - equal:
           path: spec.selector.matchLabels['app.kubernetes.io/name']
           value: "artifact-caching-proxy"
+
+  - it: should generate a custom service with specified values
+    template: service.yaml
+    set:
+      service:
+        type: LoadBalancer
+        annotations:
+          foo.bar/something: hello
+          foo.bar/other: 12
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-artifact-caching-proxy
+      - equal:
+          path: metadata.annotations["foo.bar/something"]
+          value: hello
+      - equal:
+          path: metadata.annotations["foo.bar/other"]
+          value: 12
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http

--- a/charts/artifact-caching-proxy/tests/defaults_test.yaml
+++ b/charts/artifact-caching-proxy/tests/defaults_test.yaml
@@ -6,6 +6,7 @@ templates:
   - nginx-default-configmap.yaml
   - statefulset.yaml
   - pdb.yaml
+  - service.yaml
 tests:
   - it: should not generate any ingress with default values
     template: ingress.yaml
@@ -86,3 +87,27 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: should generate a ClusterIP service with defaults
+    template: service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-artifact-caching-proxy
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: artifact-caching-proxy
+      - notExists:
+          path: metadata.annotations
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204

This PR allows passing custom Service annotations if we do not want to use a `ClusterIP` default service for ACP