### PR TITLE
feat(mirrorbits-parent) allow creating addition ingresses to support advanced routing cases

### DIFF
--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 2.0.45
+version: 2.1.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/mirrorbits-parent/templates/additional-ingresses.yaml
+++ b/charts/mirrorbits-parent/templates/additional-ingresses.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.global.ingress.enabled }}
+  {{- range $index, $addIngress := .Values.global.ingress.additionalIngresses }}
+    {{- $ingressName := printf "%s-%d" (include "mirrorbits-parent.name" $) (add $index 1) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $ingressName }}
+  labels:
+{{ include "mirrorbits-parents.labels" $ | indent 4 }}
+  {{- with $addIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+    {{- with $addIngress.className }}
+  ingressClassName: {{ . }}
+    {{- end }}
+    {{- with $addIngress.tls }}
+  tls:
+      {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+      {{- end }}
+    {{- end }}
+  rules:
+    {{- range $addIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+      {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "mirrorbits-parent.ingressBackendName" (dict "currentBackendService" .backendService "rootContext" $) }}
+                port:
+                  number: {{ include "mirrorbits-parent.ingressBackendPort" (dict "currentBackendService" .backendService "rootContext" $) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
+++ b/charts/mirrorbits-parent/tests/custom_values_ingress_test.yaml
@@ -3,65 +3,10 @@ values:
   - values/custom.yaml
 templates:
   - ingress.yaml
+  - additional-ingresses.yaml
 tests:
-  - it: should create ingress with a single HTTP host and defaults ingress values
-    template: ingress.yaml
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Ingress
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-mirrorbits-parent
-      - notExists:
-          path: metadata.annotations
-      - notExists:
-          path: spec.ingressClassName
-      - notExists:
-          path: spec.tls
-      - equal:
-          path: spec.rules[0].host
-          value: company.org
-      - equal:
-          path: spec.rules[0].http.paths[0].path
-          value: /
-      - equal:
-          path: spec.rules[0].http.paths[0].pathType
-          value: Prefix
-      - notExists:
-          path: spec.rules[1]
-      - equal:
-          path: spec.rules[0].http.paths[0].backend.service.name
-          value: RELEASE-NAME-mirrorbits
-      - equal:
-          path: spec.rules[0].http.paths[0].backend.service.port.number
-          value: 7777
   - it: should create ingress with multiple hosts and multiple paths with full customized values
     template: ingress.yaml
-    set:
-      global:
-        ingress:
-          className: my-ingress-class
-          annotations:
-            'app.kubernetes/whatever-with-chars': 'same/here-right'
-          hosts:
-            - host: company.org
-              paths:
-                - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
-                  backendService: httpd
-                - path: /
-                  backendService: mirrorbits
-                  pathType: ImplementationSpecific
-            - host: fallback.company.org
-              paths:
-                - path: /
-                  backendService: httpd
-          tls:
-            - secretName: ingress-tls
-              hosts:
-                - company.org
-                - fallback.company.org
     asserts:
       - hasDocuments:
           count: 1
@@ -172,3 +117,87 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Cannot use mirrorbits as backend if it is disabled."
+  - it: should create additional ingresses (from customized values)
+    template: additional-ingresses.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Ingress
+      - documentIndex: 1
+        isKind:
+          of: Ingress
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-parent-1
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-parent-2
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: "/$1$2/index.html"
+      - documentIndex: 0
+        notExists:
+          path: spec.ingressClassName
+      - documentIndex: 1
+        equal:
+          path: spec.ingressClassName
+          value: bar
+      - documentIndex: 0
+        notExists:
+          path: spec.tls
+      - documentIndex: 1
+        equal:
+          path: spec.tls[0].secretName
+          value: ubersecret
+      - documentIndex: 1
+        equal:
+          path: spec.tls[0].hosts[0]
+          value: company.org
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].host
+          value: localhost
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-httpd
+      - documentIndex: 0
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].host
+          value: company.org
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /(.*)(/|$)
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-mirrorbits
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 7777

--- a/charts/mirrorbits-parent/tests/values/custom.yaml
+++ b/charts/mirrorbits-parent/tests/values/custom.yaml
@@ -13,11 +13,45 @@ httpd:
 global:
   ingress:
     enabled: true
+    className: my-ingress-class
+    annotations:
+      'app.kubernetes/whatever-with-chars': 'same/here-right'
     hosts:
       - host: company.org
         paths:
+          - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
+            backendService: httpd
           - path: /
             backendService: mirrorbits
+            pathType: ImplementationSpecific
+      - host: fallback.company.org
+        paths:
+          - path: /
+            backendService: httpd
+    tls:
+      - secretName: ingress-tls
+        hosts:
+          - company.org
+          - fallback.company.org
+    additionalIngresses:
+      - hosts:
+          - host: localhost
+            paths:
+              - path: /
+                backendService: httpd
+      - className: bar
+        annotations:
+          "nginx.ingress.kubernetes.io/rewrite-target": "/$1$2/index.html"
+        hosts:
+          - host: company.org
+            paths:
+              - path: /(.*)(/|$)
+                pathType: ImplementationSpecific
+                backendService: mirrorbits
+        tls:
+          - secretName: ubersecret
+            hosts:
+              - company.org
   storage:
       enabled: true
       storageClassName: super-fast-storage

--- a/charts/mirrorbits-parent/values.yaml
+++ b/charts/mirrorbits-parent/values.yaml
@@ -28,6 +28,21 @@ global:
     #   - secretName: ingress-tls
     #     hosts:
     #       - company.org
+    ## Specify a list of additional Ingress objects to cover advanced routing use cases (default: empty object list)
+    # additionalIngresses:
+    # - className: public-nginx
+    #   annotations:
+    #     foo: bar
+    #   hosts:
+    #     - host: company.org
+    #       paths:
+    #         - path: /.*$
+    #           ## Note: the "path" objects allows defining which path matches which backend webservice component (possible values: mirrorbits or httpd)
+    #           backendService: httpd
+    #   tls:
+    #     - secretName: ingress-tls
+    #       hosts:
+    #         - company.org
 
   ## Persistent Storage used across components
   storage:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2284762944, we need to specify 2 ingress objects to support routing in the case of updates.jenkins.io, but not for get.jenkins.io.

This PR introduces a new `ingress.additionalIngresses` value to supply multiple additional ingresses definitions to the `mirrorbits-parent` chart.

Tested locally (unit test + k3d) and on production with the following PR: https://github.com/jenkins-infra/kubernetes-management/pull/5536