### PR TITLE
feat!(mirrorbits) define mirrorbits.conf using (visible) values

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 2.4.5
+version: 3.0.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/NOTES.txt
+++ b/charts/mirrorbits/templates/NOTES.txt
@@ -2,10 +2,10 @@
 Check for deprecated values
 */}}
 {{- if .Values.conf }}
-[⚠️ WARNING] Found legacy value `conf` deprecated with the version 3.x of th chart. Please check the new value `config` instead.
+[⚠️ WARNING] Found legacy value `conf` deprecated with the version 3.x of the chart. Please check the new value `config` instead.
 {{- end }}
 {{- if .Values.logs }}
-[⚠️ WARNING] Found legacy value `logs` deprecated with the version 3.x of th chart. Please check the new value `config.logs` instead.
+[⚠️ WARNING] Found legacy value `logs` deprecated with the version 3.x of the chart. Please check the new value `config.logs` instead.
 {{- end }}
 
 1. Get the application URL by running these commands:

--- a/charts/mirrorbits/templates/NOTES.txt
+++ b/charts/mirrorbits/templates/NOTES.txt
@@ -1,3 +1,13 @@
+{{/*
+Check for deprecated values
+*/}}
+{{- if .Values.conf }}
+[⚠️ WARNING] Found legacy value `conf` deprecated with the version 3.x of th chart. Please check the new value `config` instead.
+{{- end }}
+{{- if .Values.logs }}
+[⚠️ WARNING] Found legacy value `logs` deprecated with the version 3.x of th chart. Please check the new value `config.logs` instead.
+{{- end }}
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -68,3 +68,88 @@ emptyDir: {}
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Ensure coherent name of the mirrorbits configuration object (so deployment has the correct key)
+*/}}
+{{- define "mirrorbits.config-secretname" -}}
+  {{ include "mirrorbits.fullname" . }}-config
+{{- end -}}
+
+{{/*
+Template of the mirrorbits configuration file
+*/}}
+{{- define "mirrorbits.configmap" -}}
+###################
+##### GENERAL #####
+###################
+## Path to the local repository
+Repository: {{ .Values.config.repository }}
+## Path to the templates (default autodetect)
+Templates: {{ .Values.config.templates }}
+## Path to the GeoIP2 mmdb databases
+GeoipDatabasePath: {{ .Values.config.geoipDatabase }}
+## Enable Gzip compression
+Gzip: {{ .Values.config.gzip }}
+## Host an port to listen on
+ListenAddress: :{{ .Values.config.port }}
+  {{- if and .Values.config.logs .Values.config.logs.enabled }}
+## Path where to store logs
+LogDir: {{ .Values.config.logs.path }}
+  {{- end }}
+
+  {{- with .Values.config.redis }}
+####################
+##### DATABASE #####
+####################
+## Redis host and port
+RedisAddress: {{ .address }}
+## Redis password (if any)
+RedisPassword: {{ .password }}
+## Redis database ID (if any)
+RedisDB: {{ .dbId }}
+  {{- end }}
+
+###################
+##### MIRRORS #####
+###################
+## Relative path to the trace file within the repository (optional).
+## The file must contain the number of seconds since epoch and should
+## be updated every minute (or so) with a cron on the master repository.
+TraceFileLocation: {{ .Values.config.traceFile }}
+## Interval between two scans of the local repository.
+## The repository scan will index new and removed files and collect file
+## sizes and checksums.
+## This should, more or less, match the frequency where the local repo
+## is updated.
+RepositoryScanInterval: {{ .Values.config.repositoryScanInterval }}
+## Enable or disable specific hashing algorithms
+Hashes:
+  SHA256: On
+  SHA1: On
+  MD5: On
+## Maximum number of concurrent mirror synchronization to do (rsync/ftp)
+ConcurrentSync: {{ .Values.config.concurentSync }}
+## Interval in minutes between mirror scan
+ScanInterval: {{ .Values.config.repositoryScanInterval }}
+## Interval in minutes between mirrors HTTP health checks
+CheckInterval: {{ .Values.config.checkInterval }}
+## Allow a mirror to issue an HTTP redirect.
+## Setting this to true will disable the mirror if a redirect is detected.
+DisallowRedirects: {{ .Values.config.disallowRedirects }}
+## Disable a mirror if an active file is missing (HTTP 404)
+DisableOnMissingFile: {{ .Values.config.disableOnMissingFile }}
+  {{- with .Values.config.fallbacks }}
+## List of mirrors to use as fallback which will be used in case mirrorbits
+## is unable to answer a request because the database is unreachable.
+## Note: Mirrorbits will redirect to one of these mirrors based on the user
+## location but won't be able to know if the mirror has the requested file.
+## Therefore only put your most reliable and up-to-date mirrors here.
+Fallbacks:
+    {{ range . }}
+  - URL: {{ .url }}
+    CountryCode: {{ .countryCode }}
+    ContinentCode: {{ .continentCode }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,17 +36,19 @@ spec:
               containerPort: 8080
               protocol: TCP
           volumeMounts:
-            - name: conf
+            - name: mirrorbits-config
               mountPath: /etc/mirrorbits
               readOnly: true
             - name: geoipdata
-              mountPath: /usr/share/GeoIP
+              mountPath: {{ .Values.config.geoipDatabase }}
               readOnly: true
+            {{- if and .Values.config .Values.config.logs .Values.config.logs.enabled }}
             - name: logs
-              mountPath: /var/log/mirrorbits
+              mountPath: {{ .Values.config.logs.path }}
               readOnly: false
+            {{- end }}
             - name: data
-              mountPath: /srv/repo
+              mountPath: {{ .Values.config.repository }}
               readOnly: true
           livenessProbe:
             httpGet:
@@ -106,15 +109,17 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-        - name: conf
+        - name: mirrorbits-config
           secret:
-            secretName: {{ include "mirrorbits.fullname" . }}
+            secretName: {{ include "mirrorbits.config-secretname" . }}
             items:
               - key: mirrorbits.conf
                 path: mirrorbits.conf
         - name: geoipdata
           emptyDir: {}
+        {{- if and .Values.config .Values.config.logs .Values.config.logs.enabled }}
         - name: logs
-          {{- toYaml .Values.logs.volume | nindent 10 }}
+          {{- toYaml .Values.config.logs.volume | nindent 10 }}
+        {{- end }}
         - name: data
           {{- include "mirrorbits.data-volume" . | nindent 10}}

--- a/charts/mirrorbits/templates/secrets.yaml
+++ b/charts/mirrorbits/templates/secrets.yaml
@@ -1,11 +1,3 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "mirrorbits.fullname" . }}
-type: Opaque
-data:
-  mirrorbits.conf: {{ .Values.conf | b64enc }}
 {{- if and .Values.geoipupdate.account_id .Values.geoipupdate.license_key }}
 ---
 apiVersion: v1
@@ -28,4 +20,12 @@ data:
   {{- range $key, $val := .Values.repository.secrets.data }}
   {{ $key }}: {{ $val | b64enc }}
   {{- end }}
-{{- end -}}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mirrorbits.config-secretname" . }}
+type: Opaque
+data:
+  "mirrorbits.conf": {{ include "mirrorbits.configmap" . | b64enc }}

--- a/charts/mirrorbits/templates/service.yaml
+++ b/charts/mirrorbits/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 8080
+      targetPort: {{ .Values.config.port }}
       protocol: TCP
       name: http
   selector:

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -7,62 +7,8 @@ templates:
   - pdb.yaml
   - persistentVolume.yaml
   - persistentVolumeClaim.yaml
-set:
-  replicaCount: 2
-  image:
-    pullPolicy: Always
-  geoipupdate:
-    account_id: my-account-id
-    license_key: my-license-key
-  ingress:
-    enabled: true
-    hosts:
-      - host: chart-example.local
-        paths:
-        - path: /
-          pathType: IfNotPresent
-  logs:
-    volume:
-      persistentVolumeClaim:
-        claimName: foobar
-  repository:
-    name: mirrorbits-binary
-    persistentVolumeClaim:
-      enabled: true
-      spec:
-        accessModes:
-          - ReadWriteMany
-        storageClassName: azurefile-csi-premium
-        resources:
-          requests:
-            storage: 1000Gi
-        volumeName: mirrorbits-binary
-    persistentVolume:
-      enabled: true
-      spec:
-        capacity:
-          storage: 1000Gi
-        storageClassName: azurefile-csi-premium
-        accessModes:
-          - ReadWriteMany
-        persistentVolumeReclaimPolicy: Retain
-        csi:
-          driver: file.csi.azure.com
-          readOnly: false
-          volumeHandle: mirrorbits-binary  # make sure this volumeid is unique for every identical share in the cluster
-          volumeAttributes:
-            resourceGroup: prod-core-releases
-            shareName: mirrorbits
-          nodeStageSecretRef:
-            name: mirrorbits-binary
-            namespace: mirrorbits
-        mountOptions:
-          - dir_mode=0755
-    secrets:
-      enabled: true
-      data:
-        azurestorageaccountkey: 'SuperSecretKey!'
-        azurestorageaccountname: storage-account-in-az
+values:
+  - values/custom.yaml
 tests:
   - it: Should set the correct service selector labels when a fullNameOverride is specified
     template: service.yaml
@@ -92,7 +38,11 @@ tests:
       - equal:
           path: spec.replicas
           value: 2
-      # Log volumes is a custom PVC
+      # Custom GeoIP mountpath
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /geo-data
+      # Log volumes is a custom PVC in a custom mount path
       - equal:
           path: spec.template.spec.volumes[2].name
           value: logs
@@ -104,7 +54,7 @@ tests:
           value: logs
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
-          value: /var/log/mirrorbits
+          value: /custom
       # Data Volume
       - equal:
           path: spec.template.spec.volumes[3].name
@@ -117,7 +67,7 @@ tests:
           value: data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /srv/repo
+          value: /DATA
   - it: should create ingress with pathType set to the specified custom value by default
     template: ingress.yaml
     asserts:
@@ -186,18 +136,122 @@ tests:
       - documentIndex: 0
         equal:
           path: metadata.name
-          value: RELEASE-NAME-mirrorbits
-      - documentIndex: 1
-        isKind:
-          of: Secret
-      - documentIndex: 1
-        equal:
-          path: metadata.name
           value: RELEASE-NAME-mirrorbits-geoipupdate
-      - documentIndex: 2
+      - documentIndex: 1
         isKind:
           of: Secret
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
           path: metadata.name
           value: RELEASE-NAME-mirrorbits-binary
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-config
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Repository: /DATA'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Templates: /custom-tpls'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'GeoipDatabasePath: /geo-data'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Gzip: false'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'ListenAddress: :7777'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'LogDir: /custom'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Fallbacks'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'RedisAddress: redis-master.internal.company.org:6379'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'RedisPassword: SuperSecretRedisPassword'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'RedisDB: 4'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Fallbacks:'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: '- URL: https://fallback.company.org'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'CountryCode: DE'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'ContinentCode: EU'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'DisallowRedirects: false'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'DisableOnMissingFile: false'
+          decodeBase64: true
+      - documentIndex: 2
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'TraceFileLocation: /TIME'
+          decodeBase64: true
+  - it: should create a custom service
+    template: service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 7777

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -32,22 +32,41 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
-      # Configuration is a read-only mount of a secret
+      # Configuration is a read-only mount of a configmap
       - equal:
           path: spec.template.spec.volumes[0].name
-          value: conf
+          value: mirrorbits-config
       - equal:
           path: spec.template.spec.volumes[0].secret.secretName
-          value: RELEASE-NAME-mirrorbits
+          value: RELEASE-NAME-mirrorbits-config # same as the secret's metadata.name below
+      - equal:
+          path: spec.template.spec.volumes[0].secret.items[0].key
+          value: mirrorbits.conf
+      - equal:
+          path: spec.template.spec.volumes[0].secret.items[0].path
+          value: mirrorbits.conf
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
-          value: conf
+          value: mirrorbits-config
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].mountPath
           value: /etc/mirrorbits
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].readOnly
           value: true
+      # GeoIP is an emptyDir, with default mountpath
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: geoipdata
+      - equal:
+          path: spec.template.spec.volumes[1].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: geoipdata
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /usr/share/GeoIP
       # Log volumes is an emptydir by default (and you can write in it)
       - equal:
           path: spec.template.spec.volumes[2].name
@@ -95,7 +114,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should only create the mirrorbits conf secret by default
+  - it: should create only 1 secret by default (mirrorbits configuration)
     template: secrets.yaml
     asserts:
       - hasDocuments:
@@ -104,4 +123,70 @@ tests:
           of: Secret
       - equal:
           path: metadata.name
+          value: RELEASE-NAME-mirrorbits-config
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Repository: /srv/repo'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Templates: /usr/share/mirrorbits/templates'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'GeoipDatabasePath: /usr/share/GeoIP'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Gzip: false'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'ListenAddress: :8080'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'LogDir: /var/log/mirror'
+          decodeBase64: true
+      - matchRegex:
+            path: data["mirrorbits.conf"]
+            pattern: 'DisallowRedirects: true'
+            decodeBase64: true
+      - matchRegex:
+            path: data["mirrorbits.conf"]
+            pattern: 'DisableOnMissingFile: true'
+            decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'TraceFileLocation: /trace'
+          decodeBase64: true
+      - notMatchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Fallbacks'
+          decodeBase64: true
+      - notMatchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'Redis'
+          decodeBase64: true
+  - it: should create a ClusterIP service with default settings
+    template: service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
           value: RELEASE-NAME-mirrorbits
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080

--- a/charts/mirrorbits/tests/parent_values_test.yaml
+++ b/charts/mirrorbits/tests/parent_values_test.yaml
@@ -5,61 +5,9 @@ templates:
   - secrets.yaml
   - persistentVolume.yaml
   - persistentVolumeClaim.yaml
-set:
-  # Mock chart parent inherited global values passed to subcharts
-  global:
-    storage:
-      enabled: true
-      claimNameTpl: '{{ default "parent-chart-shared-data" }}'
-    ingress:
-      enabled: true
-  # Try to specify a ingress which must be ignored (parent prevails)
-  ingress:
-    enabled: true
-    hosts:
-      - host: chart-example.local
-        paths:
-        - path: /
-          pathType: IfNotPresent
-  # Try to specify a PV which must be ignored (parent prevails)
-  repository:
-    name: mirrorbits-binary
-    persistentVolumeClaim:
-      enabled: true
-      spec:
-        accessModes:
-          - ReadWriteMany
-        storageClassName: azurefile-csi-premium
-        resources:
-          requests:
-            storage: 1000Gi
-        volumeName: mirrorbits-binary
-    persistentVolume:
-      enabled: true
-      spec:
-        capacity:
-          storage: 1000Gi
-        storageClassName: azurefile-csi-premium
-        accessModes:
-          - ReadWriteMany
-        persistentVolumeReclaimPolicy: Retain
-        csi:
-          driver: file.csi.azure.com
-          readOnly: false
-          volumeHandle: mirrorbits-binary  # make sure this volumeid is unique for every identical share in the cluster
-          volumeAttributes:
-            resourceGroup: prod-core-releases
-            shareName: mirrorbits
-          nodeStageSecretRef:
-            name: mirrorbits-binary
-            namespace: mirrorbits
-        mountOptions:
-          - dir_mode=0755
-    secrets:
-      enabled: true
-      data:
-        azurestorageaccountkey: 'SuperSecretKey!'
-        azurestorageaccountname: storage-account-in-az
+values:
+  - values/global.yaml
+  - values/custom.yaml
 tests:
   - it: should define a customized "mirrorbits" deployment
     template: deployment.yaml
@@ -80,7 +28,7 @@ tests:
           value: data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].mountPath
-          value: /srv/repo
+          value: /DATA
   - it: should not create any ingress
     template: ingress.yaml
     asserts:
@@ -96,13 +44,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should only create the mirrorbits conf secret (global storage overrides local PVC secrets)
+  - it: should create one GeoIP secret and the default config secret
     template: secrets.yaml
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
+          count: 2
+      - documentIndex: 0
+        isKind:
           of: Secret
-      - equal:
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
           path: metadata.name
-          value: RELEASE-NAME-mirrorbits
+          value: RELEASE-NAME-mirrorbits-geoipupdate
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-mirrorbits-config

--- a/charts/mirrorbits/tests/values/custom.yaml
+++ b/charts/mirrorbits/tests/values/custom.yaml
@@ -1,0 +1,79 @@
+replicaCount: 2
+image:
+  pullPolicy: Always
+geoipupdate:
+  account_id: my-account-id
+  license_key: my-license-key
+ingress:
+  enabled: true
+  hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        pathType: IfNotPresent
+service:
+  type: LoadBalancer
+  port: 443
+config:
+  repository: /DATA
+  templates: /custom-tpls
+  geoipDatabase: /geo-data
+  gzip: false
+  port: 7777
+  traceFile: /TIME
+  repositoryScanInterval: 10
+  concurentSync: 9
+  checkInterval: 60
+  disallowRedirects: false
+  disableOnMissingFile: false
+  redis:
+    address: redis-master.internal.company.org:6379
+    password: SuperSecretRedisPassword
+    dbId: 4
+  logs:
+    path: /custom
+    volume:
+      persistentVolumeClaim:
+        claimName: foobar
+  fallbacks:
+    - url: https://fallback.company.org
+      countryCode: DE
+      continentCode: EU
+repository:
+  name: mirrorbits-binary
+  persistentVolumeClaim:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadWriteMany
+      storageClassName: azurefile-csi-premium
+      resources:
+        requests:
+          storage: 1000Gi
+      volumeName: mirrorbits-binary
+  persistentVolume:
+    enabled: true
+    spec:
+      capacity:
+        storage: 1000G
+      storageClassName: azurefile-csi-premium
+      accessModes:
+        - ReadWriteMany
+      persistentVolumeReclaimPolicy: Retain
+      csi:
+        driver: file.csi.azure.com
+        readOnly: false
+        volumeHandle: mirrorbits-binary  # make sure this volumeid is unique for every identical share in the cluster
+        volumeAttributes:
+          resourceGroup: prod-core-releases
+          shareName: mirrorbits
+        nodeStageSecretRef:
+          name: mirrorbits-binary
+          namespace: mirrorbits
+      mountOptions:
+        - dir_mode=0755
+  secrets:
+    enabled: true
+    data:
+      azurestorageaccountkey: 'SuperSecretKey!'
+      azurestorageaccountname: storage-account-in-az

--- a/charts/mirrorbits/tests/values/global.yaml
+++ b/charts/mirrorbits/tests/values/global.yaml
@@ -1,0 +1,7 @@
+# Mock chart parent inherited global values passed to subcharts
+global:
+  storage:
+    enabled: true
+    claimNameTpl: '{{ default "parent-chart-shared-data" }}'
+  ingress:
+    enabled: true

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -67,17 +67,44 @@ geoipupdate:
   license_key: ""
   editions: GeoLite2-ASN GeoLite2-City GeoLite2-Country
   update_frequency: 24
-logs:
-  volume:
-    emptyDir: {}
-    ## Volume contains the Pod Volume definition. Example with an existing PVC:
-    # persistentVolumeClaim:
-    #   claimName: <PVC name>
-# mirrorbits.conf data, to be completed as secret with Redis credentials
-conf: |
-  Repository: /srv/repo
-  Templates: /usr/share/mirrorbits/templates
-  RedisAddress: mirrors-redis-master:6379
+## config: specify mirrorbits configuration items
+config:
+  repository: /srv/repo
+  templates: /usr/share/mirrorbits/templates
+  geoipDatabase: /usr/share/GeoIP
+  disallowRedirects: true
+  disableOnMissingFile: true
+  ## config.logs specify where to mount mirrorbits detailled logs directory.
+  logs:
+    # Wether to use mirrorbits detaileld logs or not
+    enabled: true
+    ## config.logs.path specifies the mountpath of the volume (and set the mirrorbits configuration item)
+    path: /var/log/mirrorbits
+    ## config.logs.volume contains the Pod Volume definition for mirrorbits logs
+    volume:
+      emptyDir: {}
+      # Example with an existing PVC:
+      # persistentVolumeClaim:
+      #   claimName: <PVC name>
+  gzip: false
+  port: 8080
+  traceFile: /trace
+  ## Interval in minutes between mirror scan
+  scanInterval: 30
+  ## Interval between two scans of the local repository. This should, more or less, match the frequency where the local repo is updated.
+  repositoryScanInterval: 5
+  concurentSync: 5
+  ## Interval in minutes between mirrors HTTP health checks
+  checkInterval: 1
+  ## config.redis specifies the Redis configuration
+  # redis:
+  #   address: redis.local:6379
+  #   password: superSecretValueForRedis
+  #   dbId: 0
+  fallbacks: []
+  # - URL: https://fallback.company.org
+  #   CountryCode: DE
+  #   ContinentCode: EU
 repository:
   name: mirrorbits-binary
   persistentVolumeClaim:


### PR DESCRIPTION
It introduces a new `config` top-level value with a set of default values mapping to mirrorbit reference configuration. Implementation shifts from a Secret to a ConfigMap.

Note that this ConfigMap could hold a Redis password but RBAC allows reading it in clear if you can exec to the container so the secret does not protect more than ConfigMap.

BREAKING CHANGE: the value `conf` is deprecated and ignored. Check the new `config` value instead.
BREAKING CHANGE: the value `logs` is deprecated and ignored. Check the new `config.logs` value instead.