### PR TITLE
chore(updatecli) track maxmind/geoipupdates from ghcr.io and only on the new chart

### DIFF
--- a/updatecli/updatecli.d/geoipupdates.yaml
+++ b/updatecli/updatecli.d/geoipupdates.yaml
@@ -13,7 +13,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  latestMirrorbitsRelease:
+  lastVersion:
     name: Get latest version of maxmind/geoipupdate
     kind: githubrelease
     spec:
@@ -41,18 +41,16 @@ targets:
     kind: helmchart
     spec:
       name: charts/geoipupdates
-      # appversion: true
       file: Chart.yaml
       key: $.appVersion
-#     scmid: default
+    scmid: default
 
-# actions:
-#   default:
-#     kind: github/pullrequest
-#     scmid: default
-#     title: Bump `mirrorbits` docker images and helm chart versions
-#     spec:
-#       labels:
-#         - dependencies
-#         - mirrorbits
-#         - geoip
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `ghcr.io/maxmind/geoipupdate` docker image to {{ source `lastVersion` }}
+    spec:
+      labels:
+        - dependencies
+        - geoipupdates

--- a/updatecli/updatecli.d/geoipupdates.yaml
+++ b/updatecli/updatecli.d/geoipupdates.yaml
@@ -1,0 +1,58 @@
+name: Bump `ghcr.io/maxmind/geoipupdate` docker image and helm chart versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestMirrorbitsRelease:
+    name: Get latest version of maxmind/geoipupdate
+    kind: githubrelease
+    spec:
+      owner: maxmind
+      repository: geoipupdate
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkGeoIPDockerImagePublished:
+    name: Ensure that the image "ghcr.io/maxmind/geoipupdate:<found_version>" is published
+    kind: dockerimage
+    spec:
+      image: ghcr.io/maxmind/geoipupdate
+      architectures:
+        - "arm64"
+      # Tag comes from sourceid
+
+targets:
+  updateGeoIP:
+    name: "Update chart appVersion"
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
+    kind: helmchart
+    spec:
+      name: charts/geoipupdates
+      # appversion: true
+      file: Chart.yaml
+      key: $.appVersion
+#     scmid: default
+
+# actions:
+#   default:
+#     kind: github/pullrequest
+#     scmid: default
+#     title: Bump `mirrorbits` docker images and helm chart versions
+#     spec:
+#       labels:
+#         - dependencies
+#         - mirrorbits
+#         - geoip

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -21,14 +21,6 @@ sources:
       repository: "docker-mirrorbits"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-  latestGeoIPRelease:
-    name: Get latest version of GeoIP
-    kind: githubrelease
-    spec:
-      owner: "maxmind"
-      repository: "geoipupdate"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
 
 conditions:
   checkMirrorbitsDockerImagePublished:
@@ -37,14 +29,6 @@ conditions:
     kind: dockerimage
     spec:
       image: "jenkinsciinfra/mirrorbits"
-      architecture: "amd64"
-      # Tag comes from sourceid
-  checkGeoIPDockerImagePublished:
-    name: Ensure that the image "maxmindinc/geoipupdate:<found_version>" is published on the DockerHub
-    sourceid: latestGeoIPRelease
-    kind: dockerimage
-    spec:
-      image: "maxmindinc/geoipupdate"
       architecture: "amd64"
       # Tag comes from sourceid
 
@@ -58,14 +42,6 @@ targets:
       key: $.image.tag
       versionincrement: patch
     scmid: default
-  updateGeoIP:
-    name: "Update maxmindinc/geoipupdate docker image version"
-    sourceid: latestGeoIPRelease
-    kind: helmchart
-    spec:
-      name: charts/mirrorbits
-      key: $.geoipupdate.image.tag
-    scmid: default
 
 actions:
   default:
@@ -76,4 +52,3 @@ actions:
       labels:
         - dependencies
         - mirrorbits
-        - geoip


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4240

Follow up of #1273 

This PR tracks the maxmind/geoipupdates version for the new GHCR Docker image in the new geoipupdates charts only, and no more on mirrorbits!