### PR TITLE
chore(GHA/release.yml) remove deprecated input of `setup-helm` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          
       # Needed for subchart dependencies
       - name: Add jenkins-infra Helm repository
         run: helm repo add jenkins-infra https://jenkins-infra.github.io/helm-charts


### PR DESCRIPTION
Fixes the warning message `Warning: Input 'token' has been deprecated with message: GitHub token is no longer required` found (example: https://github.com/jenkins-infra/helm-charts/actions/runs/10430641720/job/28889414774#step:4:1)