### PR TITLE
feat(mirrorbits) allow passing annotations to pod template

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 4.0.2
+version: 4.1.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         app.kubernetes.io/name: {{ include "mirrorbits.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum | trunc 63 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       automountServiceAccountToken: false
     {{- with .Values.imagePullSecrets }}

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -89,6 +89,13 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
           value: 500m
+      - equal:
+          path: spec.template.metadata.annotations["ad.datadoghq.com/mirrorbits.logs"]
+          value: |
+            [
+              {"type":"file","path":"/custom/downloads.log","source":"file","service":"RELEASE-NAME"},
+              {"source":"container","service":"RELEASE-NAME"}
+            ]
   - it: should create ingress with pathType set to the specified custom value by default
     template: ingress.yaml
     asserts:

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -108,6 +108,8 @@ tests:
           path: spec.template.spec.containers[0].securityContext
       - notExists:
           path: spec.template.spec.containers[0].resources
+      - notExists:
+          path: spec.template.metadata.annotations
   - it: should not define any persistent volume
     template: persistentVolumes.yaml
     asserts:

--- a/charts/mirrorbits/tests/values/custom.yaml
+++ b/charts/mirrorbits/tests/values/custom.yaml
@@ -90,3 +90,9 @@ containerSecurityContext:
 resources:
   limits:
     cpu: 500m
+annotations:
+  ad.datadoghq.com/mirrorbits.logs: |
+    [
+      {"type":"file","path":"/custom/downloads.log","source":"file","service":"RELEASE-NAME"},
+      {"source":"container","service":"RELEASE-NAME"}
+    ]

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -9,6 +9,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+annotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 securityContext: {}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2294769030

In order to have datadog collecting logs, we need to specify annotation for the Deployment's Pod template as per https://docs.datadoghq.com/containers/kubernetes/log/?tab=helm#example-log-autodiscovery-annotations.