### PR TITLE
feat!(mirrorbits) defaults download logs to stdout

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 4.1.0
+version: 5.0.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -100,7 +100,7 @@ GeoipDatabasePath: {{ .Values.config.geoipDatabase }}
 Gzip: {{ .Values.config.gzip }}
 ## Host an port to listen on
 ListenAddress: :{{ .Values.config.port }}
-  {{- if and .Values.config.logs .Values.config.logs.enabled }}
+  {{- if and .Values.config.logs .Values.config.logs.path }}
 ## Path where to store logs
 LogDir: {{ .Values.config.logs.path }}
   {{- end }}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -50,9 +50,9 @@ spec:
             - name: geoipdata
               mountPath: {{ .Values.config.geoipDatabase }}
               readOnly: true
-            {{- if and .Values.config .Values.config.logs .Values.config.logs.enabled }}
+            {{- with .Values.config.logs.volume }}
             - name: logs
-              mountPath: {{ .Values.config.logs.path }}
+              mountPath: {{ $.Values.config.logs.path }}
               readOnly: false
             {{- end }}
             - name: data
@@ -89,9 +89,9 @@ spec:
             items:
               - key: mirrorbits.conf
                 path: mirrorbits.conf
-        {{- if and .Values.config .Values.config.logs .Values.config.logs.enabled }}
+        {{- with .Values.config.logs.volume }}
         - name: logs
-          {{- toYaml .Values.config.logs.volume | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         - name: data
           {{- include "mirrorbits.data-volume" . | nindent 10}}

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -56,10 +56,10 @@ tests:
           value: true
       # GeoIP is an emptyDir, with default mountpath
       - equal:
-          path: spec.template.spec.volumes[3].name
+          path: spec.template.spec.volumes[2].name
           value: geoipdata
       - equal:
-          path: spec.template.spec.volumes[3].emptyDir
+          path: spec.template.spec.volumes[2].emptyDir
           value: {}
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
@@ -70,38 +70,25 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].readOnly
           value: true
-      # Log volumes is an emptydir by default (and you can write in it)
+      # Data Volume is an emptyDir by default (but readonly)
       - equal:
           path: spec.template.spec.volumes[1].name
-          value: logs
+          value: data
       - equal:
           path: spec.template.spec.volumes[1].emptyDir
           value: {}
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].name
-          value: logs
+          value: data
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].mountPath
-          value: /var/log/mirrorbits
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].readOnly
-          value: false
-      # Data Volume is an emptyDir by default (but readonly)
-      - equal:
-          path: spec.template.spec.volumes[2].name
-          value: data
-      - equal:
-          path: spec.template.spec.volumes[2].emptyDir
-          value: {}
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].name
-          value: data
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
           value: /srv/repo
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[3].readOnly
+          path: spec.template.spec.containers[0].volumeMounts[2].readOnly
           value: true
+      # There are no log volumes
+      - notExists:
+          path: spec.template.spec.volumes[3]
       - notExists:
           path: spec.template.spec.securityContext
       - notExists:
@@ -156,10 +143,6 @@ tests:
           pattern: 'ListenAddress: :8080'
           decodeBase64: true
       - matchRegex:
-          path: data["mirrorbits.conf"]
-          pattern: 'LogDir: /var/log/mirror'
-          decodeBase64: true
-      - matchRegex:
             path: data["mirrorbits.conf"]
             pattern: 'DisallowRedirects: true'
             decodeBase64: true
@@ -178,6 +161,10 @@ tests:
       - matchRegex:
           path: data["mirrorbits.conf"]
           pattern: 'ScanInterval: 30'
+          decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'LogDir: /var/logs/mirrorbits'
           decodeBase64: true
       - notMatchRegex:
           path: data["mirrorbits.conf"]

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: jenkinsciinfra/mirrorbits
-  tag: 0.2.44
+  tag: 0.2.45
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""
@@ -68,16 +68,13 @@ config:
   disableOnMissingFile: true
   ## config.logs specify where to mount mirrorbits detailled logs directory.
   logs:
-    # Wether to use mirrorbits detaileld logs or not
-    enabled: true
-    ## config.logs.path specifies the mountpath of the volume (and set the mirrorbits configuration item)
-    path: /var/log/mirrorbits
+    ## config.logs.path specifies the logs path. Default as a download.logs symlink to stdout
+    path: /var/logs/mirrorbits
     ## config.logs.volume contains the Pod Volume definition for mirrorbits logs
-    volume:
-      emptyDir: {}
-      # Example with an existing PVC:
-      # persistentVolumeClaim:
-      #   claimName: <PVC name>
+    ## Example with an existing PVC:
+    # volume:
+    #   persistentVolumeClaim:
+    #     claimName: <PVC name>
   gzip: false
   port: 8080
   traceFile: /trace


### PR DESCRIPTION
Logs are enabled by default but may quickly fill the default emptyDir volume. In order to have proper logs rotation, let's use stdout (in addition to current logs). It uses a symlink from the image in /var/log/mirrorbits/download.logs to stdout.

BREAKING CHANGE: No more logs volume and download logs are sent to the stdout.