### PR TITLE
fix(mirrorbits) ensure we can run with readonly filesystem along with non root user

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.0.0
+version: 5.0.1
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             - name: data
               mountPath: {{ .Values.config.repository }}
               readOnly: true
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false
           livenessProbe:
             httpGet:
               path: /?mirrorstats
@@ -102,3 +105,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        - name: tmpdir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Mi

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -80,6 +80,25 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].mountPath
           value: /DATA
+      # Tempdir uses a tmpfs volume with a 100Mi limit
+      - equal:
+          path: spec.template.spec.volumes[4].name
+          value: tmpdir
+      - equal:
+          path: spec.template.spec.volumes[4].emptyDir.medium
+          value: Memory
+      - equal:
+          path: spec.template.spec.volumes[4].emptyDir.sizeLimit
+          value: 100Mi
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: tmpdir
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
+          value: /tmp
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].readOnly
+          value: false
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -54,22 +54,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].readOnly
           value: true
-      # GeoIP is an emptyDir, with default mountpath
-      - equal:
-          path: spec.template.spec.volumes[2].name
-          value: geoipdata
-      - equal:
-          path: spec.template.spec.volumes[2].emptyDir
-          value: {}
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[1].name
-          value: geoipdata
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
-          value: /usr/share/GeoIP
-      - equal:
-          path: spec.template.spec.containers[0].volumeMounts[1].readOnly
-          value: true
       # Data Volume is an emptyDir by default (but readonly)
       - equal:
           path: spec.template.spec.volumes[1].name
@@ -86,9 +70,44 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[2].readOnly
           value: true
+      # GeoIP is an emptyDir, with default mountpath
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: geoipdata
+      - equal:
+          path: spec.template.spec.volumes[2].emptyDir
+          value: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: geoipdata
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /usr/share/GeoIP
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].readOnly
+          value: true
+      # Tempdir uses a tmpfs volume with a 100Mi limit
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: tmpdir
+      - equal:
+          path: spec.template.spec.volumes[3].emptyDir.medium
+          value: Memory
+      - equal:
+          path: spec.template.spec.volumes[3].emptyDir.sizeLimit
+          value: 100Mi
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: tmpdir
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /tmp
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].readOnly
+          value: false
       # There are no log volumes
       - notExists:
-          path: spec.template.spec.volumes[3]
+          path: spec.template.spec.volumes[4]
       - notExists:
           path: spec.template.spec.securityContext
       - notExists:

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 annotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
-securityContext: {}
+containerSecurityContext: {}
 # capabilities:
 #   drop:
 #   - ALL


### PR DESCRIPTION
This PR fixes the following elements to allow using complete security contexts in production:

- Fix the values to specify the correct container)-level security context directive
- Use a `tmpfs` for the `/tmp` mountpoint with a size limited to 100Mi (otherwise non root user are not allowed to write in the container /tmp)