### PR TITLE
feat(nginx-website): allow to customise nginx configuration

### DIFF
--- a/charts/nginx-website/Chart.yaml
+++ b/charts/nginx-website/Chart.yaml
@@ -5,4 +5,4 @@ description: A Helm chart for serving website with nginx
 name: nginx-website
 maintainers:
 - name: lemeurherve
-version: 0.1.4
+version: 0.2.0

--- a/charts/nginx-website/templates/deployment.yaml
+++ b/charts/nginx-website/templates/deployment.yaml
@@ -30,19 +30,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: {{ .Values.service.port }}
               scheme: HTTP
             initialDelaySeconds: 20
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: {{ .Values.service.port }}
               scheme: HTTP
             initialDelaySeconds: 20
             timeoutSeconds: 5

--- a/charts/nginx-website/templates/nginx-configmap.yaml
+++ b/charts/nginx-website/templates/nginx-configmap.yaml
@@ -6,11 +6,14 @@ metadata:
 data:
   default.conf: |
     server {
-      listen       80;
-      server_name  localhost;
+      listen       {{ .Values.service.port }};
+      server_name  {{ .Values.nginx.serverName }};
       location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
+        root   {{ .Values.nginx.slashLocation.root }};
+        index  {{ .Values.nginx.slashLocation.index }};
+        autoindex {{ .Values.nginx.slashLocation.autoindex }};
+        {{- if .Values.nginx.slashLocation.tryFiles }}
+        try_files {{ .Values.nginx.slashLocation.tryFiles }};
+        {{- end}}
       }
     }

--- a/charts/nginx-website/tests/custom_values_test.yaml
+++ b/charts/nginx-website/tests/custom_values_test.yaml
@@ -2,6 +2,17 @@
 suite: Test with custom values
 templates:
   - pdb.yaml
+  - nginx-configmap.yaml
+set:
+  nginx:
+    serverName: _
+    slashLocation:
+      root: /custom
+      index: custom.html
+      autoindex: "off"
+      tryFiles: $uri /index.html
+  service:
+    port: 8080
 tests:
   - it: should ensure the pdb has correct spec
     template: pdb.yaml
@@ -18,3 +29,28 @@ tests:
       - equal:
           path: spec.selector.matchLabels['app.kubernetes.io/name']
           value: "nginx-website"
+  - it: should create a custom nginx configuration
+    template: nginx-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nginx-website
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'listen       8080;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'root   /custom;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'index  custom.html;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'autoindex off;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'try_files \$uri /index.html;'

--- a/charts/nginx-website/tests/defaults_test.yaml
+++ b/charts/nginx-website/tests/defaults_test.yaml
@@ -60,4 +60,4 @@ tests:
           pattern: 'autoindex on;'
       - notMatchRegex:
           path: data["default.conf"]
-          pattern: 'try_files $uri /index.html;'
+          pattern: 'try_files \$uri /index.html;'

--- a/charts/nginx-website/tests/defaults_test.yaml
+++ b/charts/nginx-website/tests/defaults_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: Should generate a deployment with the default values
+  - it: should generate a deployment with the default values
     template: deployment.yaml
     asserts:
       - hasDocuments:
@@ -33,3 +33,31 @@ tests:
           value: {}
       - notExists:
           path: spec.template.spec.containers[0].resources
+  - it: should create a default nginx configuration
+    template: nginx-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-nginx-website
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'listen       80;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'server_name  localhost;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'root   /usr/share/nginx/html;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'index  index.html index.htm;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'autoindex on;'
+      - notMatchRegex:
+          path: data["default.conf"]
+          pattern: 'try_files $uri /index.html;'

--- a/charts/nginx-website/values.yaml
+++ b/charts/nginx-website/values.yaml
@@ -1,7 +1,4 @@
 ---
-# Default values for plugins.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
 replicaCount: 1
 image:
   repository: nginx
@@ -50,8 +47,17 @@ affinity: {}
 htmlVolume: {}
 podDisruptionBudget:
   minAvailable: 1
-# ## Secrets values
+## Secrets values
 # # name of the azure storage account to be used
 # azureStorageAccountName:
 # # key for accessing the azure storage account
 # azureStorageAccountKey:
+## nginx default.conf
+nginx:
+  serverName: localhost
+  slashLocation:
+    root: /usr/share/nginx/html
+    index: index.html index.htm
+    autoindex: "on"
+    ## Uncomment to enable try_files directive
+    # tryFiles: $uri /index.html


### PR DESCRIPTION
This PR allows to customise nginx configuration so we can set for example a `try_files` directive, required for React applications for direct links. 

It also sets the port in deployment.yaml to `service.port` in order to use the same value in every template.

Note: I've kept current values to avoid breaking existing releases using this chart, these default values could be updated to more sensible ones like `server_name _;` in the future.

Ref:
- https://github.com/jenkins-infra/stats.jenkins.io/issues/118
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2298635602