### PR TITLE
fix(jenkins-jobs) GH App credential owner must be a groovy string

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 2.0.0
+version: 2.0.1
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -378,7 +378,7 @@ configNode << 'org.jenkinsci.plugins.github__branch__source.GitHubAppCredentials
   appID('{{ coalesce .appID .appId .appid }}')
   privateKey('''{{ .privateKey }}''')
   {{- if .owner }}
-  owner({{ .owner }})
+  owner('{{ .owner }}')
   {{- end }}
 }
 {{- end }}

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -140,7 +140,7 @@ tests:
                         description('Github App installed on the external GitHub organization 'lemmings'')
                         appID('123456')
                         privateKey('''${GITHUB_APP_LEMMINGS}''')
-                        owner(lemmings)
+                        owner('lemmings')
                       }
 
                       configNode << 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl' {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4165#issuecomment-2304081117

The `owner()` function in a GH App credential JobDSL definition must be a string. Otherwise it is considered a Groovy reference and any special character is treated as a Groovy operator (such as the `-` of `jenkins-infra`...).