### PR TITLE
fix(mirrorbits) probes should use the specified exposed port

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.1.2
+version: 5.1.3
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/NOTES.txt
+++ b/charts/mirrorbits/templates/NOTES.txt
@@ -26,6 +26,6 @@ Check for deprecated values
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mirrorbits.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080/?mirrorstats to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Visit http://127.0.0.1:{{ .Values.config.port }}/?mirrorstats to use your application"
+  kubectl port-forward $POD_NAME {{ .Values.config.port }}:80
 {{- end }}

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -69,11 +69,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /?mirrorstats
-              port: 8080
+              port: {{ .Values.config.port }}
           readinessProbe:
             httpGet:
               path: /?mirrorstats
-              port: 8080
+              port: {{ .Values.config.port }}
       {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -130,6 +130,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[1].containerPort
           value: 3333
+      # Probes are define with custom setup
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /?mirrorstats
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 7777
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /?mirrorstats
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 7777
   - it: "should create two ingresses: one for HTTP and the other for CLI"
     template: ingresses.yaml
     asserts:

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -124,7 +124,21 @@ tests:
           path: spec.template.metadata.annotations
       - notExists:
           path: spec.template.spec.containers[0].ports[1]
+      # Probes are define with default setups
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /?mirrorstats
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /?mirrorstats
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
   - it: should not define any persistent volume
+
     template: persistentVolumes.yaml
     asserts:
       - hasDocuments:


### PR DESCRIPTION
While reviewing, I realized that I forgot the probes in https://github.com/jenkins-infra/helm-charts/pull/1268