### PR TITLE
fix(jenkins-jobs) fix deprecated syntax for GH Fork Discovery traits

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 2.0.1
+version: 2.0.2
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -152,9 +152,14 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
             gitHubBranchDiscovery {
               strategyId(1) // 1-only branches that are not pull requests
             }
-            // Only Origin Pull Request
             gitHubPullRequestDiscovery {
               strategyId(1) // 1-Merging the pull request with the current target branch revision
+            }
+            gitHubForkDiscovery {
+              strategyId(1) // 1-Merging the pull request with the current target branch revision
+              trust {
+                gitHubTrustPermissions()
+              }
             }
             pruneStaleBranchTrait()
             {{- if not .disableTagDiscovery }}
@@ -210,14 +215,6 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
       daysToKeepStr("{{ .orphanedItemStrategyDaysToKeep | default "" }}")
       numToKeepStr("{{ .orphanedItemStrategyNumToKeep | default "" }}")
       abortBuilds(true)
-    }
-  }
-  configure { node ->
-    def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-    // Not discovered by Job-DSL: need to be configured as raw-XML
-    traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-      strategyId(1) // 1-Merging the pull request with the current target branch revision
-      trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
     }
   }
 

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -128,9 +128,14 @@ tests:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
-                              // Only Origin Pull Request
                               gitHubPullRequestDiscovery {
                                 strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
                               }
                               pruneStaleBranchTrait()
                               gitHubTagDiscovery()
@@ -176,14 +181,6 @@ tests:
                         daysToKeepStr("")
                         numToKeepStr("")
                         abortBuilds(true)
-                      }
-                    }
-                    configure { node ->
-                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                      // Not discovered by Job-DSL: need to be configured as raw-XML
-                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                        strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
 

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -58,9 +58,14 @@ tests:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
-                              // Only Origin Pull Request
                               gitHubPullRequestDiscovery {
                                 strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
                               }
                               pruneStaleBranchTrait()
                               gitHubTagDiscovery()
@@ -106,14 +111,6 @@ tests:
                         daysToKeepStr("")
                         numToKeepStr("")
                         abortBuilds(true)
-                      }
-                    }
-                    configure { node ->
-                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                      // Not discovered by Job-DSL: need to be configured as raw-XML
-                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                        strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
 
@@ -171,9 +168,14 @@ tests:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
-                              // Only Origin Pull Request
                               gitHubPullRequestDiscovery {
                                 strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
                               }
                               pruneStaleBranchTrait()
                               gitHubTagDiscovery()
@@ -219,14 +221,6 @@ tests:
                         daysToKeepStr("")
                         numToKeepStr("")
                         abortBuilds(true)
-                      }
-                    }
-                    configure { node ->
-                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                      // Not discovered by Job-DSL: need to be configured as raw-XML
-                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                        strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
 
@@ -286,9 +280,14 @@ tests:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
-                              // Only Origin Pull Request
                               gitHubPullRequestDiscovery {
                                 strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
                               }
                               pruneStaleBranchTrait()
                               gitHubTagDiscovery()
@@ -334,14 +333,6 @@ tests:
                         daysToKeepStr("")
                         numToKeepStr("")
                         abortBuilds(true)
-                      }
-                    }
-                    configure { node ->
-                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                      // Not discovered by Job-DSL: need to be configured as raw-XML
-                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                        strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
 
@@ -406,9 +397,14 @@ tests:
                               gitHubBranchDiscovery {
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
-                              // Only Origin Pull Request
                               gitHubPullRequestDiscovery {
                                 strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
                               }
                               pruneStaleBranchTrait()
                               pullRequestLabelsBlackListFilterTrait {
@@ -448,14 +444,6 @@ tests:
                         daysToKeepStr("3")
                         numToKeepStr("10")
                         abortBuilds(true)
-                      }
-                    }
-                    configure { node ->
-                      def traits = node / 'sources' / 'data' / 'jenkins.branch.BranchSource' / 'source' / 'traits'
-                      // Not discovered by Job-DSL: need to be configured as raw-XML
-                      traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
-                        strategyId(1) // 1-Merging the pull request with the current target branch revision
-                        trust(class: 'org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission')
                       }
                     }
 


### PR DESCRIPTION
With Jenkins JobDSL, the `configure {}` block with [XML transformation](https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block#transforming-xml) should only be used as a last resort as it indicates an unsupported directive.

This PR removes the XML transformation in favor of the (now-supported) `gitHubForkDiscovery{ }` block directive.

No changes expected on generated JobDSL: verified with both unit tests (see checks) AND the local manual execution in a k3d Jenkins.