### PR TITLE
feat(jenkins-jobs) allow specifying a GitHub Branch Scan Credential for a given Folder

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Damien Duportal <damien.duportal@gmail.com>
 name: jenkins-jobs
-version: 2.0.2
+version: 2.1.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_helpers.tpl
+++ b/charts/jenkins-jobs/templates/_helpers.tpl
@@ -10,9 +10,10 @@ Generate the job-dsl configuration from specified values
     {{- range $childId, $childDef := $jobDef.children }}
       {{- /*  Jenkins + Job DSL allow to define job children by concatenating their id with the parent id, separated by a / */}}
       {{- $childFullId := printf "%s/%s" $jobId $childId }}
-      {{- $child := (dict "id" $childId "fullId" $childFullId "root" $root) }}
+      {{- $parentGithubCredential := $jobDef.childrenGithubCredential }}
+      {{- $child := (dict "id" $childId "fullId" $childFullId "root" $root "parentGithubCredential" $parentGithubCredential) }}
       {{- if $childDef }}
-      {{- $child = (merge $childDef (dict "id" $childId "fullId" $childFullId "root" $root)) }}
+      {{- $child = (merge $childDef (dict "id" $childId "fullId" $childFullId "root" $root "parentGithubCredential" $parentGithubCredential)) }}
       {{- end }}
 {{ include "generic-job-dsl-definition" $child | indent 4 }}
     {{- end -}}
@@ -123,7 +124,7 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
       source {
         github {
           id('{{ .fullId | default .id | toString }}')
-          credentialsId('{{ .githubCredentialsId | default "github-app-infra" }}')
+          credentialsId('{{ coalesce .githubCredentialsId .parentGithubCredential "github-app-infra" }}')
           configuredByUrl(true)
           repositoryUrl('https://github.com/{{ $repositoryOwner }}/{{ $repository }}')
           repoOwner('{{ $repositoryOwner }}')

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -183,3 +183,347 @@ tests:
                       }
                     }
                   }
+  - it: should use the specified (folder-level) GitHub credential for all children unless overriden
+    set:
+      jobsDefinition:
+        folder-a:
+          name: Folder A
+          kind: folder
+          credentials:
+            folder-a-github-app:
+              appId: "${GITHUB_APP_FOLDERA_APPID}"
+              privateKey: "${GITHUB_APP_FOLDERA_KEY}"
+          childrenGithubCredential: folder-a-github-app
+          children:
+            child-job-1:
+              name: Child Multibranch Job 1
+            child-job-2:
+              name: Child Multibranch Job 2
+            child-job-3:
+              name: Child Multibranch Job 3
+              githubCredentialsId: another-gh-app
+    asserts:
+      - equal:
+          path: data["jobs-definition.yaml"]
+          value: |-
+            jobs:
+              - script: >
+                  folder('folder-a') {
+                    displayName('Folder A')
+                    description('Folder A')
+
+                    properties {
+                      folderCredentialsProperty {
+                        domainCredentials {
+                          domainCredentials {
+                            domain {
+                              name('Folder A')
+                              description('Credentials for the job Folder A')
+                            }
+                          }
+                        }
+                      }
+                    }
+
+                    configure { node ->
+                      def configNode = node / 'properties' /  'com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty' /  'domainCredentialsMap' / 'entry' / 'java.util.concurrent.CopyOnWriteArrayList'
+                      configNode << 'org.jenkinsci.plugins.github__branch__source.GitHubAppCredentials'(plugin: 'github-branch-source') {
+                        scope('GLOBAL')
+                        id('folder-a-github-app')
+                        description('folder-a-github-app')
+                        appID('${GITHUB_APP_FOLDERA_APPID}')
+                        privateKey('''${GITHUB_APP_FOLDERA_KEY}''')
+                      }
+                    }
+                  }
+
+                  multibranchPipelineJob('folder-a/child-job-1') {
+                    triggers {
+                      periodicFolderTrigger {
+                        interval('2h')
+                      }
+                    }
+
+                    branchSources {
+                      branchSource {
+                        source {
+                          github {
+                            id('folder-a/child-job-1')
+                            credentialsId('folder-a-github-app')
+                            configuredByUrl(true)
+                            repositoryUrl('https://github.com/jenkins-infra/child-job-1')
+                            repoOwner('jenkins-infra')
+                            repository('child-job-1')
+                            traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/folder-a/child-job-1')
+                                typeSuffix(true)
+                              }
+                              gitHubSCMSourceStatusChecksTrait {
+                                // Note: changing this name might have impact on github branch protections if they specify status names
+                                name('jenkins')
+                                skip(true)
+                                // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                                skipNotifications(false)
+                                skipProgressUpdates(false)
+                                // Default value: false. Warning: risk of secret leak in console if the build fails
+                                // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+                                suppressLogs(true)
+                                unstableBuildNeutral(false)
+                              }
+                              gitHubBranchDiscovery {
+                                strategyId(1) // 1-only branches that are not pull requests
+                              }
+                              gitHubPullRequestDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
+                              }
+                              pruneStaleBranchTrait()
+                              gitHubTagDiscovery()
+                              pullRequestLabelsBlackListFilterTrait {
+                                labels('on-hold,ci-skip,skip-ci')
+                              }
+                              // Select branches and tags to build based on these filters
+                              headWildcardFilterWithPR {
+                                includes('main master PR-*') // only branches listed here
+                                excludes('')
+                                tagIncludes('*')
+                                tagExcludes('')
+                              }
+                            }
+                          }
+                          buildStrategies {
+                            buildAnyBranches {
+                              strategies {
+                                skipInitialBuildOnFirstBranchIndexing()
+                                buildChangeRequests {
+                                  ignoreTargetOnlyChanges(true)
+                                  ignoreUntrustedChanges(true)
+                                }
+                                buildRegularBranches()
+                                buildTags {
+                                  atLeastDays('-1')
+                                  atMostDays('3')
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    factory {
+                      workflowBranchProjectFactory {
+                        scriptPath('Jenkinsfile_k8s')
+                      }
+                    }
+                    orphanedItemStrategy {
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
+                      }
+                    }
+
+                    displayName('Child Multibranch Job 1')
+                    description('Child Multibranch Job 1')
+                  }
+
+                  multibranchPipelineJob('folder-a/child-job-2') {
+                    triggers {
+                      periodicFolderTrigger {
+                        interval('2h')
+                      }
+                    }
+
+                    branchSources {
+                      branchSource {
+                        source {
+                          github {
+                            id('folder-a/child-job-2')
+                            credentialsId('folder-a-github-app')
+                            configuredByUrl(true)
+                            repositoryUrl('https://github.com/jenkins-infra/child-job-2')
+                            repoOwner('jenkins-infra')
+                            repository('child-job-2')
+                            traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/folder-a/child-job-2')
+                                typeSuffix(true)
+                              }
+                              gitHubSCMSourceStatusChecksTrait {
+                                // Note: changing this name might have impact on github branch protections if they specify status names
+                                name('jenkins')
+                                skip(true)
+                                // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                                skipNotifications(false)
+                                skipProgressUpdates(false)
+                                // Default value: false. Warning: risk of secret leak in console if the build fails
+                                // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+                                suppressLogs(true)
+                                unstableBuildNeutral(false)
+                              }
+                              gitHubBranchDiscovery {
+                                strategyId(1) // 1-only branches that are not pull requests
+                              }
+                              gitHubPullRequestDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
+                              }
+                              pruneStaleBranchTrait()
+                              gitHubTagDiscovery()
+                              pullRequestLabelsBlackListFilterTrait {
+                                labels('on-hold,ci-skip,skip-ci')
+                              }
+                              // Select branches and tags to build based on these filters
+                              headWildcardFilterWithPR {
+                                includes('main master PR-*') // only branches listed here
+                                excludes('')
+                                tagIncludes('*')
+                                tagExcludes('')
+                              }
+                            }
+                          }
+                          buildStrategies {
+                            buildAnyBranches {
+                              strategies {
+                                skipInitialBuildOnFirstBranchIndexing()
+                                buildChangeRequests {
+                                  ignoreTargetOnlyChanges(true)
+                                  ignoreUntrustedChanges(true)
+                                }
+                                buildRegularBranches()
+                                buildTags {
+                                  atLeastDays('-1')
+                                  atMostDays('3')
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    factory {
+                      workflowBranchProjectFactory {
+                        scriptPath('Jenkinsfile_k8s')
+                      }
+                    }
+                    orphanedItemStrategy {
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
+                      }
+                    }
+
+                    displayName('Child Multibranch Job 2')
+                    description('Child Multibranch Job 2')
+                  }
+
+                  multibranchPipelineJob('folder-a/child-job-3') {
+                    triggers {
+                      periodicFolderTrigger {
+                        interval('2h')
+                      }
+                    }
+
+                    branchSources {
+                      branchSource {
+                        source {
+                          github {
+                            id('folder-a/child-job-3')
+                            credentialsId('another-gh-app')
+                            configuredByUrl(true)
+                            repositoryUrl('https://github.com/jenkins-infra/child-job-3')
+                            repoOwner('jenkins-infra')
+                            repository('child-job-3')
+                            traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/folder-a/child-job-3')
+                                typeSuffix(true)
+                              }
+                              gitHubSCMSourceStatusChecksTrait {
+                                // Note: changing this name might have impact on github branch protections if they specify status names
+                                name('jenkins')
+                                skip(true)
+                                // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                                skipNotifications(false)
+                                skipProgressUpdates(false)
+                                // Default value: false. Warning: risk of secret leak in console if the build fails
+                                // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+                                suppressLogs(true)
+                                unstableBuildNeutral(false)
+                              }
+                              gitHubBranchDiscovery {
+                                strategyId(1) // 1-only branches that are not pull requests
+                              }
+                              gitHubPullRequestDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                              }
+                              gitHubForkDiscovery {
+                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
+                              }
+                              pruneStaleBranchTrait()
+                              gitHubTagDiscovery()
+                              pullRequestLabelsBlackListFilterTrait {
+                                labels('on-hold,ci-skip,skip-ci')
+                              }
+                              // Select branches and tags to build based on these filters
+                              headWildcardFilterWithPR {
+                                includes('main master PR-*') // only branches listed here
+                                excludes('')
+                                tagIncludes('*')
+                                tagExcludes('')
+                              }
+                            }
+                          }
+                          buildStrategies {
+                            buildAnyBranches {
+                              strategies {
+                                skipInitialBuildOnFirstBranchIndexing()
+                                buildChangeRequests {
+                                  ignoreTargetOnlyChanges(true)
+                                  ignoreUntrustedChanges(true)
+                                }
+                                buildRegularBranches()
+                                buildTags {
+                                  atLeastDays('-1')
+                                  atMostDays('3')
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    factory {
+                      workflowBranchProjectFactory {
+                        scriptPath('Jenkinsfile_k8s')
+                      }
+                    }
+                    orphanedItemStrategy {
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
+                      }
+                    }
+
+                    displayName('Child Multibranch Job 3')
+                    description('Child Multibranch Job 3')
+                  }


### PR DESCRIPTION
Tested with a diff in production:

- No change by default
- Allows removing repeated directives:

```diff
diff --git a/config/jenkins-jobs_infra.ci.jenkins.io.yaml b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
index ae5da785..771022d4 100644
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -28,6 +28,7 @@ jobsDefinition:
         appId: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_ID}"
         owner: "jenkins-infra"
         privateKey: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_PRIVATE_KEY}"
+    childrenGithubCredential: github-app-infra.ci.jenkins.io-docker-jobs
     children:
       acceptance-test-harness:
         name: "Jenkins CI Acceptance Test Harness (ATH) Docker Image"
@@ -41,51 +42,30 @@ jobsDefinition:
             owner: "jenkinsci"
             privateKey: "${GITHUB_APP_JENKINSCI_PRIVATE_KEY}"
       account-app:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       docker-404:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-builder:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-confluence-data:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-crond:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-inbound-agents:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-lts:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-weeklyci:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-infraci:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-keycloak-theme:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-ldap:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-mirrorbits:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-openvpn:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-packaging:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-plugin-site-issues:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-rsyncd:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       ircbot:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       plugin-health-scoring:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       plugin-site-api:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       rating:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       uplink:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
```