### PR TITLE
chore(jenkins-jobs) code and metadata cleanup

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Jenkins Jobs Definition from YAML to job-dsl
 icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
-  - name: Damien Duportal <damien.duportal@gmail.com>
+  - name: Jenkins Infra Team <jenkins-infra-team@googlegroups.com>
 name: jenkins-jobs
-version: 2.1.0
+version: 2.1.1
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/README.md
+++ b/charts/jenkins-jobs/README.md
@@ -48,10 +48,12 @@ Requirements:
 ## You can fine tune the Kubernetes version with the file tests/manual/k3d.yaml (and other parameters)
 k3d cluster create --config=./tests/manual/k3d.yaml
 
-# Now your $KUBECONFIG is set to use this cluster named 'jenkins-jobs'. You can install the Jenkins + this chart in it for testing
+# Now your $KUBECONFIG is set to use this cluster named 'jenkins-jobs'. You can install Jenkins + this chart in it for testing
 ## You can specify custom values for the jenkins-jobs chart with the file ./
 helmfile apply -f ./tests/manual/helmfile-k3d.yaml
 ```
+
+Now Jenkins is available on <http://localhost> with the username `admin` and the password `butler`, as specified in `./tests/manual/jenkins-jobs_values.yaml`.
 
 You can clean up with the following command:
 

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_commons.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_commons.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate the job-dsl configuration from specified values
+*/}}
+{{- define "jobs-dsl-config" }}
+  {{- $root := . }}
+  {{- range $jobId, $jobDef := .Values.jobsDefinition }}
+- script: >
+    {{- include "generic-job-dsl-definition" (merge $jobDef (dict "id" $jobId "root" $root)) | indent 4 }}
+    {{- range $childId, $childDef := $jobDef.children }}
+      {{- /*  Jenkins + Job DSL allow to define job children by concatenating their id with the parent id, separated by a / */}}
+      {{- $childFullId := printf "%s/%s" $jobId $childId }}
+      {{- $parentGithubCredential := $jobDef.childrenGithubCredential }}
+      {{- $child := (dict "id" $childId "fullId" $childFullId "root" $root "parentGithubCredential" $parentGithubCredential) }}
+      {{- if $childDef }}
+        {{- $child = (merge $childDef (dict "id" $childId "fullId" $childFullId "root" $root "parentGithubCredential" $parentGithubCredential)) }}
+      {{- end }}
+      {{- include "generic-job-dsl-definition" $child | indent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/******************* Jobs (foler, multibranch, etc.) ***********************/}}
+{{/*
+Generate the job-dsl definition of a single generic item
+*/}}
+{{- define "generic-job-dsl-definition" }}
+  {{- $jobKind := .kind | default "multibranchPipelineJob" }}
+  {{- if eq "folder" $jobKind }}
+    {{- include "folder-job-dsl-definition" . }}
+  {{- else if eq "multibranchPipelineJob" $jobKind }}
+    {{- include "multibranch-job-dsl-definition" . }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Generate the the "common" elements for any job-dsl definition
+*/}}
+{{- define "common-job-dsl-definition" }}
+displayName('{{ coalesce .name .id }}')
+description('{{ coalesce .description .name .id }}')
+  {{- include "common-credentials-job-dsl-definition" . }}
+{{- end }}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate the job-dsl definition of a folder
+*/}}
+{{- define "folder-job-dsl-definition" }}
+folder('{{ .id }}') {
+  {{- include "common-job-dsl-definition" . | indent 2 }}
+}
+{{- end }}

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_commons.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_commons.tpl
@@ -20,7 +20,6 @@ Generate the job-dsl configuration from specified values
   {{- end }}
 {{- end }}
 
-{{/******************* Jobs (foler, multibranch, etc.) ***********************/}}
 {{/*
 Generate the job-dsl definition of a single generic item
 */}}

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
@@ -1,0 +1,117 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate the job-dsl definition of a multibranch job
+*/}}
+{{- define "multibranch-job-dsl-definition" }}
+  {{- $repository := .repository | default .id }}
+  {{- $repositoryOwner := .repoOwner | default "jenkins-infra" }}
+multibranchPipelineJob('{{ .fullId | default .id }}') {
+  triggers {
+    periodicFolderTrigger {
+      interval('2h')
+    }
+  }
+
+  branchSources {
+    branchSource {
+      source {
+        github {
+          id('{{ .fullId | default .id | toString }}')
+          credentialsId('{{ coalesce .githubCredentialsId .parentGithubCredential "github-app-infra" }}')
+          configuredByUrl(true)
+          repositoryUrl('https://github.com/{{ $repositoryOwner }}/{{ $repository }}')
+          repoOwner('{{ $repositoryOwner }}')
+          repository('{{ $repository }}')
+          traits {
+            gitHubNotificationContextTrait {
+              contextLabel('jenkins/{{ .root.Values.jenkinsFqdn | default "localhost" }}/{{ .fullId | default .id }}')
+              typeSuffix(true)
+            }
+            gitHubSCMSourceStatusChecksTrait {
+              // Note: changing this name might have impact on github branch protections if they specify status names
+              name({{ .githubCheckName | default "jenkins" | squote }})
+    {{- if empty .enableGitHubChecks }}
+              skip(true)
+    {{- else }}
+              skip({{ not .enableGitHubChecks }})
+    {{- end }}
+              // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+              skipNotifications(false)
+              skipProgressUpdates(false)
+              // Default value: false. Warning: risk of secret leak in console if the build fails
+              // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+              suppressLogs(true)
+              unstableBuildNeutral(false)
+            }
+            gitHubBranchDiscovery {
+              strategyId(1) // 1-only branches that are not pull requests
+            }
+            gitHubPullRequestDiscovery {
+              strategyId(1) // 1-Merging the pull request with the current target branch revision
+            }
+            gitHubForkDiscovery {
+              strategyId(1) // 1-Merging the pull request with the current target branch revision
+              trust {
+                gitHubTrustPermissions()
+              }
+            }
+            pruneStaleBranchTrait()
+    {{- if not .disableTagDiscovery }}
+            gitHubTagDiscovery()
+    {{- end }}
+            pullRequestLabelsBlackListFilterTrait {
+              labels('on-hold,ci-skip,skip-ci')
+            }
+            // Select branches and tags to build based on these filters
+            headWildcardFilterWithPR {
+              includes('{{ .branchIncludes | default "main master PR-*" }}') // only branches listed here
+              excludes('{{ .branchExcludes | default "" }}')
+              tagIncludes('*')
+              tagExcludes('')
+            }
+          }
+        }
+        buildStrategies {
+          buildAnyBranches {
+            strategies {
+    {{- if eq (.buildOnFirstIndexing | toString) "<nil>" }}
+              skipInitialBuildOnFirstBranchIndexing()
+    {{- end }}
+              buildChangeRequests {
+                ignoreTargetOnlyChanges(true)
+    {{- if eq (.allowUntrustedChanges | toString) "<nil>" }}
+                ignoreUntrustedChanges(true)
+    {{- else }}
+                ignoreUntrustedChanges({{ not .allowUntrustedChanges }})
+    {{- end }}
+              }
+              buildRegularBranches()
+    {{- if not .disableTagDiscovery }}
+              buildTags {
+                atLeastDays('-1')
+                atMostDays('3')
+              }
+    {{- end }}
+            }
+          }
+        }
+      }
+    }
+  }
+  factory {
+    workflowBranchProjectFactory {
+      scriptPath('{{ .jenkinsfilePath | default "Jenkinsfile_k8s" }}')
+    }
+  }
+  orphanedItemStrategy {
+    defaultOrphanedItemStrategy {
+      pruneDeadBranches(true)
+      daysToKeepStr("{{ .orphanedItemStrategyDaysToKeep | default "" }}")
+      numToKeepStr("{{ .orphanedItemStrategyNumToKeep | default "" }}")
+      abortBuilds(true)
+    }
+  }
+
+  {{- include "common-job-dsl-definition" . | indent 2 }}
+}
+{{- end }}

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -73,7 +73,6 @@ tests:
                               name('Folder A')
                               description('Credentials for the job Folder A')
                             }
-
                             credentials {
                               awsCredentialsImpl {
                                 scope('GLOBAL')
@@ -117,7 +116,6 @@ tests:
                         }
                       }
                     }
-
                     configure { node ->
                       def configNode = node / 'properties' /  'com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty' /  'domainCredentialsMap' / 'entry' / 'java.util.concurrent.CopyOnWriteArrayList'
 
@@ -224,7 +222,6 @@ tests:
                         }
                       }
                     }
-
                     configure { node ->
                       def configNode = node / 'properties' /  'com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty' /  'domainCredentialsMap' / 'entry' / 'java.util.concurrent.CopyOnWriteArrayList'
                       configNode << 'org.jenkinsci.plugins.github__branch__source.GitHubAppCredentials'(plugin: 'github-branch-source') {
@@ -236,7 +233,6 @@ tests:
                       }
                     }
                   }
-
                   multibranchPipelineJob('folder-a/child-job-1') {
                     triggers {
                       periodicFolderTrigger {
@@ -329,11 +325,9 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Child Multibranch Job 1')
                     description('Child Multibranch Job 1')
                   }
-
                   multibranchPipelineJob('folder-a/child-job-2') {
                     triggers {
                       periodicFolderTrigger {
@@ -426,11 +420,9 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Child Multibranch Job 2')
                     description('Child Multibranch Job 2')
                   }
-
                   multibranchPipelineJob('folder-a/child-job-3') {
                     triggers {
                       periodicFolderTrigger {
@@ -523,7 +515,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Child Multibranch Job 3')
                     description('Child Multibranch Job 3')
                   }

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -61,12 +61,10 @@ tests:
                     displayName('Parent Folder')
                     description('This is the parent folder')
                   }
-
                   folder('child-folder-1') {
                     displayName('Child Folder 1')
                     description('This is the first sub-folder')
                   }
-
                   folder('child-folder-2') {
                     displayName('Child Folder 2')
                     description('This is the second sub-folder')
@@ -90,7 +88,6 @@ tests:
                     displayName('Parent Folder')
                     description('Parent Folder')
                   }
-
                   multibranchPipelineJob('parent-folder/child-job') {
                     triggers {
                       periodicFolderTrigger {
@@ -183,7 +180,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Child Multibranch Job')
                     description('Child Multibranch Job')
                   }

--- a/charts/jenkins-jobs/tests/manual/jenkins_values.yaml
+++ b/charts/jenkins-jobs/tests/manual/jenkins_values.yaml
@@ -10,6 +10,19 @@ controller:
         jenkins:
           numExecutors: 0
       security: |
+        jenkins:
+          securityRealm:
+            local:
+              allowsSignup: false
+              users:
+                - id: "admin"
+                  password: "butler"
+          authorizationStrategy:
+            loggedInUsersCanDoAnything:
+              allowAnonymousRead: false
+          crumbIssuer:
+            standard:
+              excludeClientIPFromCrumb: true
         security:
           gitHostKeyVerificationConfiguration:
             sshHostKeyVerificationStrategy:

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -113,7 +113,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Default Job')
                     description('Default Job')
                   }
@@ -223,7 +222,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Job A')
                     description('Job A for team A')
                   }
@@ -335,7 +333,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Job B')
                     description('Job B for team B')
                   }
@@ -446,7 +443,6 @@ tests:
                         abortBuilds(true)
                       }
                     }
-
                     displayName('Job C')
                     description('Job C')
                   }


### PR DESCRIPTION
- Use the properer maintainer in Chart.yaml
- Split template into different files per theme to avoid a big helpers file
- Cleanup indentation in template helpers
- Improve e2e manual testing (avoid crumb errors and add Jenkins default auth.)

----

Note: tried a `diff` on production: it only remove whitespaces and empty lines \o/

----

Note: about file naming conventions in Helm: https://helm.sh/docs/chart_template_guide/named_templates/#partials-and-_-files

> files whose name begins with an underscore (_) are assumed to not have a manifest inside. These files are not rendered to Kubernetes object definitions, but are available everywhere within other chart templates for use.