### PR TITLE
fix(jenkins-jobs) avoid error logs by ensuring no spaces before newlines

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Jenkins Infra Team <jenkins-infra-team@googlegroups.com>
 name: jenkins-jobs
-version: 2.2.0
+version: 2.2.1
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/jcasc-jobs-config.yaml
+++ b/charts/jenkins-jobs/templates/jcasc-jobs-config.yaml
@@ -11,8 +11,8 @@ metadata:
     "app.kubernetes.io/instance": "{{ $.Release.Name }}"
     {{ .Values.jenkinsName }}-jenkins-config: "true"
 data:
-  {{ .Values.keyName }}.yaml: |-
+  {{ .Values.keyName }}.yaml: |
     jobs:
-      - script: >
+      - script: |
 {{ indent 6 (include "jobs-dsl-config" $) }}
 {{- end }}

--- a/charts/jenkins-jobs/tests/credentials_test.yaml
+++ b/charts/jenkins-jobs/tests/credentials_test.yaml
@@ -8,9 +8,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   folder('folder-a') {
                     displayName('Folder A')

--- a/charts/jenkins-jobs/tests/folders_test.yaml
+++ b/charts/jenkins-jobs/tests/folders_test.yaml
@@ -8,9 +8,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   folder('folder-a') {
                     displayName('Folder A')
@@ -26,9 +26,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   folder('folder-b') {
                     displayName('Folder B')
@@ -40,9 +40,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   folder('parent-folder') {
                     displayName('Parent Folder')

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -8,9 +8,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   multibranchPipelineJob('default-job') {
                     triggers {
@@ -113,9 +113,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   multibranchPipelineJob('joba') {
                     triggers {
@@ -218,9 +218,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   multibranchPipelineJob('job-b') {
                     triggers {
@@ -323,9 +323,9 @@ tests:
     asserts:
       - equal:
           path: data["jobs-definition.yaml"]
-          value: |-
+          value: |
             jobs:
-              - script: >
+              - script: |
 
                   multibranchPipelineJob('job-c') {
                     triggers {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4165#issuecomment-2323979337

This PR is a fixup of both #1313 and #1316.

Unit tests are not enough to catch this issue, but end to end (manual) tests allowed me to reproduce the production error.
Might be worth adding e2e tests (at least here in a first step).

About the fix: when it comes to multi-line strings with YAML: https://yaml-multiline.info/ is the way.

Root cause of the errors is described in https://github.com/helm/helm/issues/5446#issuecomment-866994215:

> However removing any instance of a space before a newline fixed it.

by removing some of the whitespaces (pain with Helm :'(), I ended up into having spaces before empty lines which confused JobDSL.
It was visible by exec-ing on the Jenkins pod and showing the YAML file content which showed broken JobDSL, while the ConfigMap itself did not show it immediately.

This change had been applied on both the local end to end  (test from scratch) + on infra.ci (with a JCasC reload: no error message). Hoping it should be ok (but the fact it fixed the error on local e2e k3d is positive)

