### PR TITLE
feat(mirrorbits) allow setting up OutputMode in mirrorbits configuration

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.1.5
+version: 5.2.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -114,6 +114,11 @@ RPCListenAddress: 0.0.0.0:{{ .Values.cli.port }}
 RPCPassword: {{ . | quote }}
     {{- end }}
   {{- end }}
+## OutputMode can take on the three values:
+##  - redirect: HTTP redirect to the destination file on the selected mirror
+##  - json: return a json document for pre-treatment by an application
+##  - auto: based on the Accept HTTP header
+OutputMode: {{ .Values.config.outputMode | default "auto" }}
   {{- with .Values.config.redis }}
 ####################
 ##### DATABASE #####

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -365,6 +365,11 @@ tests:
           path: data["mirrorbits.conf"]
           pattern: 'RPCPassword: "SuperSecretPasswordForCli"'
           decodeBase64: true
+      - documentIndex: 1
+        matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'OutputMode: redirect'
+          decodeBase64: true
   - it: "should create two (custom) services: HTTP and cli"
     template: services.yaml
     asserts:

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -207,6 +207,10 @@ tests:
           path: data["mirrorbits.conf"]
           pattern: 'LogDir: /var/logs/mirrorbits'
           decodeBase64: true
+      - matchRegex:
+          path: data["mirrorbits.conf"]
+          pattern: 'OutputMode: auto'
+          decodeBase64: true
       - notMatchRegex:
           path: data["mirrorbits.conf"]
           pattern: 'Fallbacks'

--- a/charts/mirrorbits/tests/values/custom.yaml
+++ b/charts/mirrorbits/tests/values/custom.yaml
@@ -24,6 +24,7 @@ config:
   checkInterval: 60
   disallowRedirects: false
   disableOnMissingFile: false
+  outputMode: redirect
   redis:
     address: redis-master.internal.company.org:6379
     password: SuperSecretRedisPassword


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2345352162

This PR allows setting up the `OutputMode` directive in mirrorbits. It keeps the default to `auto` (non breaking change)