### PR TITLE
feat(nginx-website): allow setting redirections

### DIFF
--- a/charts/nginx-website/Chart.yaml
+++ b/charts/nginx-website/Chart.yaml
@@ -5,4 +5,4 @@ description: A Helm chart for serving website with nginx
 name: nginx-website
 maintainers:
 - name: lemeurherve
-version: 0.2.0
+version: 0.3.0

--- a/charts/nginx-website/templates/nginx-configmap.yaml
+++ b/charts/nginx-website/templates/nginx-configmap.yaml
@@ -16,4 +16,11 @@ data:
         try_files {{ .Values.nginx.slashLocation.tryFiles }};
         {{- end}}
       }
+      {{- if .Values.nginx.redirections }}
+      {{- range .Values.nginx.redirections }}
+      location {{ .location }} {
+        return {{ .returnedCode }} {{ .destination}}$request_uri;
+      }
+      {{- end}}
+      {{- end}}
     }

--- a/charts/nginx-website/tests/custom_values_test.yaml
+++ b/charts/nginx-website/tests/custom_values_test.yaml
@@ -11,6 +11,13 @@ set:
       index: custom.html
       autoindex: "off"
       tryFiles: $uri /index.html
+    redirections:
+      - location: /alocation
+        returnedCode: 301
+        destination: https://awebsite.example/apath/
+      - location: /anotherlocation
+        returnedCode: 302
+        destination: https://anotherwebsite.example/anotherpath/
   service:
     port: 8080
 tests:
@@ -54,3 +61,15 @@ tests:
       - matchRegex:
           path: data["default.conf"]
           pattern: 'try_files \$uri /index.html;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'location /alocation {'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'return 301 https://awebsite.example/apath/\$request_uri;'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'location /anotherlocation {'
+      - matchRegex:
+          path: data["default.conf"]
+          pattern: 'return 302 https://anotherwebsite.example/anotherpath/\$request_uri;'

--- a/charts/nginx-website/tests/defaults_test.yaml
+++ b/charts/nginx-website/tests/defaults_test.yaml
@@ -61,3 +61,6 @@ tests:
       - notMatchRegex:
           path: data["default.conf"]
           pattern: 'try_files \$uri /index.html;'
+      - notMatchRegex:
+          path: data["default.conf"]
+          pattern: 'return .*;'

--- a/charts/nginx-website/values.yaml
+++ b/charts/nginx-website/values.yaml
@@ -61,3 +61,8 @@ nginx:
     autoindex: "on"
     ## Uncomment to enable try_files directive
     # tryFiles: $uri /index.html
+  redirections: {}
+    ## Example:
+    # - location: /plugin-installation-trend
+    #   returnedCode: 301
+    #   destination: https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/


### PR DESCRIPTION
This PR allows defining redirections (with `return`, preferable in most cases to `rewrite`) so we can for example avoid breaking existing (old.)stats.jenkins.io URLs which pointed to files on GitHub but are not served by the new frontend, used by far more than we/I though initially.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2347009570

### Example of usage

values.yaml:
```
nginx:
  serverName: localhost
  slashLocation:
    root: /usr/share/nginx/html
    index: index.html index.htm
    autoindex: "on"
    ## Uncomment to enable try_files directive
    # tryFiles: $uri /index.html
  redirections: {}
    - location: /jenkins-stats
      returnedCode: 301
      destination: https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/
    - location: /plugin-installation-trend
      returnedCode: 301
      destination: https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/
    - location: /pluginversions
      returnedCode: 301
      destination: https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/
```

Resulting nginx config:
```
    server {
      listen       80;
      server_name  localhost;
      location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
        autoindex on;
      }
      location /jenkins-stats {
        return 301 https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/$request_uri;
      }
      location /plugin-installation-trend {
        return 301 https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/$request_uri;
      }
      location /pluginversions {
        return 301 https://raw.githubusercontent.com/jenkins-infra/infra-statistics/gh-pages/$request_uri;
      }
    }
```
