### PR TITLE
feat(mirrorbits) allow specifying existing PVCs for repository data and geoipdata

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.2.0
+version: 5.3.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/_helpers.tpl
+++ b/charts/mirrorbits/templates/_helpers.tpl
@@ -52,21 +52,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Data directory volume definition. Might be defined from parent chart templates or autonomously
-based on the presence of the global value provided by the parent chart.
+Ensure coherent name of the repository data PV/PVC objects
 */}}
-{{- define "mirrorbits.data-volume" -}}
-{{- if and (dig "global" "storage" "enabled" false .Values.AsMap) .Values.global.storage.claimNameTpl -}}
-persistentVolumeClaim:
-  claimName: {{ printf "%s" (tpl .Values.global.storage.claimNameTpl $) | trim | trunc 63 }}
-{{- else -}}
-  {{- if .Values.repository.persistentVolumeClaim.enabled -}}
-persistentVolumeClaim:
-  claimName: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
-  {{- else -}}
-emptyDir: {}
-  {{- end -}}
+{{- define "mirrorbits.data-name" -}}
+{{ .Values.repository.name }}
 {{- end -}}
+
+{{/*
+Ensure coherent name of the geoipdata PV/PVC objects
+*/}}
+{{- define "mirrorbits.geoipdata-name" -}}
+{{ .Values.geoipdata.existingPVCName | default (printf "%s-%s" (include "mirrorbits.fullname" .) "geoipdata") }}
 {{- end -}}
 
 {{/*
@@ -74,13 +70,6 @@ Ensure coherent name of the mirrorbits configuration object (so deployment has t
 */}}
 {{- define "mirrorbits.config-secretname" -}}
   {{ include "mirrorbits.fullname" . }}-config
-{{- end -}}
-
-{{/*
-Ensure coherent name of the geoipdata PV/PVC objects
-*/}}
-{{- define "mirrorbits.geoipdata" -}}
-  {{ include "mirrorbits.fullname" . }}-geoipdata
 {{- end -}}
 
 {{/*

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -102,11 +102,21 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         - name: data
-          {{- include "mirrorbits.data-volume" . | nindent 10}}
-        - name: geoipdata
-        {{- if .Values.geoipdata.persistentData.enabled }}
+          {{- if and (dig "global" "storage" "enabled" false .Values.AsMap) .Values.global.storage.claimNameTpl }}
           persistentVolumeClaim:
-            claimName: {{ include "mirrorbits.geoipdata" . }}
+            claimName: {{ printf "%s" (tpl .Values.global.storage.claimNameTpl $) | trim | trunc 63 }}
+          {{- else }}
+            {{- if or .Values.repository.persistentVolumeClaim.enabled .Values.repository.existingPVC }}
+          persistentVolumeClaim:
+            claimName: {{ include "mirrorbits.data-name" . }}
+            {{- else }}
+          emptyDir: {}
+            {{- end }}
+          {{- end }}
+        - name: geoipdata
+        {{- if or .Values.geoipdata.persistentData.enabled .Values.geoipdata.existingPVCName }}
+          persistentVolumeClaim:
+            claimName: {{ include "mirrorbits.geoipdata-name" . }}
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/charts/mirrorbits/templates/persistentVolumeClaims.yaml
+++ b/charts/mirrorbits/templates/persistentVolumeClaims.yaml
@@ -1,9 +1,9 @@
-{{ if and .Values.repository.persistentVolumeClaim.enabled (not (dig "global" "ingress" "enabled" false .Values.AsMap)) -}}
+{{ if and .Values.repository.persistentVolumeClaim.enabled (not (dig "global" "storage" "enabled" false .Values.AsMap)) -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .))  }}
+  name: {{ include "mirrorbits.data-name" . }}
 spec:
 {{ toYaml .Values.repository.persistentVolumeClaim.spec | nindent 2 }}
 {{- end }}
@@ -12,7 +12,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "mirrorbits.geoipdata" . }}
+  name: {{ include "mirrorbits.geoipdata-name" . }}
 spec:
   accessModes:
     - ReadOnlyMany
@@ -20,5 +20,5 @@ spec:
     requests:
       storage: {{ .Values.geoipdata.persistentData.capacity}}
   storageClassName: {{ .Values.geoipdata.persistentData.storageClassName}}
-  volumeName: {{ include "mirrorbits.geoipdata" . }}
+  volumeName: {{ include "mirrorbits.geoipdata-name" . }}
 {{- end }}

--- a/charts/mirrorbits/templates/persistentVolumes.yaml
+++ b/charts/mirrorbits/templates/persistentVolumes.yaml
@@ -1,11 +1,11 @@
-{{ if and .Values.repository.persistentVolume.enabled (not (dig "global" "ingress" "enabled" false .Values.AsMap)) -}}
+{{ if and .Values.repository.persistentVolume.enabled (not (dig "global" "storage" "enabled" false .Values.AsMap)) -}}
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" .)) }}
+  name: {{ include "mirrorbits.data-name" . }}
   labels:
-    data: {{ .Values.repository.name | default (printf "%s-binary" (include "mirrorbits.fullname" . )) }}
+    data: {{ include "mirrorbits.data-name" . }}
 spec:
 {{ toYaml .Values.repository.persistentVolume.spec | nindent 2 }}
 {{- end }}
@@ -14,9 +14,9 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "mirrorbits.geoipdata" . }}
+  name: {{ include "mirrorbits.geoipdata-name" . }}
   labels:
-    data: {{ include "mirrorbits.geoipdata" . }}
+    data: {{ include "mirrorbits.geoipdata-name" . }}
 spec:
   accessModes:
     - ReadOnlyMany

--- a/charts/mirrorbits/tests/custom_values_test.yaml
+++ b/charts/mirrorbits/tests/custom_values_test.yaml
@@ -441,3 +441,63 @@ tests:
         equal:
           path: spec.ports[0].targetPort
           value: 3333
+  - it: should only define a GeoIP PV when reusing existing PVCs
+    template: persistentVolumes.yaml
+    values:
+      - values/custom_existingPVC.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should only define a GeoIP PVC when reusing existing PVC for repository
+    template: persistentVolumeClaims.yaml
+    values:
+      - values/custom_existingPVC.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should set up repository to use the specified existing PVC (when specified)
+    template: deployment.yaml
+    values:
+      - values/custom_existingPVC.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      # Custom GeoIP PVC
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: geoipdata
+      - equal:
+          path: spec.template.spec.volumes[3].persistentVolumeClaim.claimName
+          value: geodataHere
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: geoipdata
+      # Log volumes is a custom PVC in a custom mount path
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: logs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].name
+          value: logs
+      # Data Volume
+      - equal:
+          path: spec.template.spec.volumes[2].name
+          value: data
+      - equal:
+          path: spec.template.spec.volumes[2].persistentVolumeClaim.claimName
+          value: anotherPVC
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].name
+          value: data
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[3].mountPath
+          value: /DATA
+      # Tempdir uses a tmpfs volume with a 100Mi limit
+      - equal:
+          path: spec.template.spec.volumes[4].name
+          value: tmpdir
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: tmpdir

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -138,7 +138,6 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: 8080
   - it: should not define any persistent volume
-
     template: persistentVolumes.yaml
     asserts:
       - hasDocuments:

--- a/charts/mirrorbits/tests/values/custom_existingPVC.yaml
+++ b/charts/mirrorbits/tests/values/custom_existingPVC.yaml
@@ -1,0 +1,11 @@
+repository:
+  name: anotherPVC
+  existingPVC: true
+  persistentVolumeClaim:
+    enabled: false
+  persistentVolume:
+    enabled: false
+geoipdata:
+  existingPVCName: geodataHere
+  persistentData:
+    enabled: false

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -108,24 +108,31 @@ config:
   #   CountryCode: DE
   #   ContinentCode: EU
 repository:
+  ## Name of the PVC (existing or to be created - see options below) to use as repository data
   name: mirrorbits-binary
+  ## Is the repository.name an existing PVC (statically or chart-externally defined)
+  existingPVC: false
+  ## Use dynamically provisioned PVC
   persistentVolumeClaim:
     enabled: false
-    # spec hold persistentVolumeClaim spec
+    ## spec holds persistentVolumeClaim spec
     spec: {}
+  ## Use dynamically provisioned PV
   persistentVolume:
     enabled: false
-    # spec hold persistentVolume spec
+    ## spec holds persistentVolume spec
     spec: {}
   secrets:
     enabled: false
-    # data hold secrets data used by persistentVolume
+    ## data hold secrets data used by persistentVolume
     data: {}
 poddisruptionbudget:
   minAvailable: 1
 geoipdata:
+  ## Is the repository.name an existing PVC (statically or chart-externally defined)
+  # existingPVCName: geoIPExistingData
   persistentData:
     enabled: false
     # capacity: 1Gi
-    # storageClassName: statically-provisionned
+    # storageClassName: statically-provisioned
     # csi: {}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649, this PR allows setting up a mirrorbits instance with existing PVC (either created by another chart release, or statically provisioned).

Tested manually on `publick8s` by setting up a manual HTTP-only instance with success (and reusing the current PVCs of updates.jenkins.io)