### PR TITLE
chore(acp/report/acme): correct a type on {{- end }} missing a space

### DIFF
--- a/charts/acme/Chart.yaml
+++ b/charts/acme/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An acme settings chart for Jenkins infra project
 name: acme
-version: 0.1.3
+version: 0.1.4
 home: "https://github.com/jenkins-infra/charts"
 maintainers:
   - name: Olblak

--- a/charts/acme/templates/clusterIssuer.yaml
+++ b/charts/acme/templates/clusterIssuer.yaml
@@ -12,4 +12,4 @@ spec:
     {{- if .Values.acme.solvers }}
     solvers:
       {{- toYaml .Values.acme.solvers | nindent 4 }}
-    {{- end}}
+    {{- end }}

--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/artifact-caching-proxy/templates/statefulset.yaml
+++ b/charts/artifact-caching-proxy/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
         volumeMounts:
           - mountPath: {{ .Values.cache.path }}
             name: {{ .Values.persistence.claimPrefix }}
-      {{- end}}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         {{- with .Values.containerSecurityContext }}

--- a/charts/reports/Chart.yaml
+++ b/charts/reports/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for reports.jenkins.io
 maintainers:
   - name: timja
 name: reports
-version: 0.4.3
+version: 0.4.4

--- a/charts/reports/templates/deployment.yaml
+++ b/charts/reports/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
-          {{- end}}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
{{- end }} require space around the `end` word