### PR TITLE
chore(updatecli): add a manifest to bump kubectl version to the kubernetes used on publick8s

### DIFF
--- a/updatecli/updatecli.d/httpd-kubectl.yaml
+++ b/updatecli/updatecli.d/httpd-kubectl.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump Kubectl version for httpd rollout restart
+name: Bump `kubectl` version for httpd rollout restart
 
 scms:
   default:
@@ -36,7 +36,7 @@ conditions:
 
 targets:
   setKubectlToolVersion:
-    name: "Bump Kubectl version for httpd rollout restart"
+    name: "Bump `kubectl` version for httpd rollout restart"
     kind: yaml
     sourceid: getKubernetesPublick8sVersion
     spec:
@@ -49,7 +49,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Kubectl version for httpd rollout restart to {{ source "getKubernetesPublick8sVersion" }}
+    title: Bump`kubectl` version for httpd rollout restart to {{ source "getKubernetesPublick8sVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/httpd-kubectl.yaml
+++ b/updatecli/updatecli.d/httpd-kubectl.yaml
@@ -1,0 +1,55 @@
+---
+name: Bump Kubectl version for httpd rollout restart
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getKubernetesPublick8sVersion:
+    kind: terraform/file
+    name: Retrieve the current version of the kubernetes used in production on publick8s
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/azure/refs/heads/main/locals.tf
+      path: locals.kubernetes_versions
+    transformers: #  as per updatecli/updatecli#1859 need to use terraform/file findsubmatch for now
+      - findsubmatch:
+          pattern: '"publick8s".*=."(.*)"'
+          captureindex: 1
+
+conditions:
+  checkDockerImagePublished:
+    name: "Test bitnami/kubectl:<getKubernetesPublick8sVersion> docker image tag"
+    kind: dockerimage
+    sourceid: getKubernetesPublick8sVersion
+    spec:
+      image: "bitnami/kubectl"
+      ## Tag from source
+
+targets:
+  setKubectlToolVersion:
+    name: "Bump Kubectl version for httpd rollout restart"
+    kind: yaml
+    sourceid: getKubernetesPublick8sVersion
+    spec:
+      file: charts/httpd/values.yaml
+      engine: yamlpath
+      key: $.httpdRestart.image.tag
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Kubectl version for httpd rollout restart to {{ source "getKubernetesPublick8sVersion" }}
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
following https://github.com/jenkins-infra/helm-charts/pull/1331 that use kubectl we need to make sure we use a version not too far from the kubernetes version we use on publick8s.

----

tested locally:

```
⚠ Bump Kubectl version for httpd rollout restart:
        Source:
                ✔ [getKubernetesPublick8sVersion] Retrieve the current version of the kubernetes used in production on publick8s
        Condition:
                ✔ [checkDockerImagePublished] Test bitnami/kubectl:<getKubernetesPublick8sVersion> docker image tag
        Target:
                ⚠ [setKubectlToolVersion] Bump Kubectl version for httpd rollout restart


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```