### PR TITLE
chore(updatecli): hotfix use `kind: helmchart` to handle the helm chart bump with the tag update

### DIFF
--- a/updatecli/updatecli.d/httpd-kubectl.yaml
+++ b/updatecli/updatecli.d/httpd-kubectl.yaml
@@ -37,12 +37,12 @@ conditions:
 targets:
   setKubectlToolVersion:
     name: "Bump `kubectl` version for httpd rollout restart"
-    kind: yaml
+    kind: helmchart
     sourceid: getKubernetesPublick8sVersion
     spec:
-      file: charts/httpd/values.yaml
-      engine: yamlpath
+      name: charts/httpd
       key: $.httpdRestart.image.tag
+      versionincrement: patch
     scmid: default
 
 actions:


### PR DESCRIPTION
following #1350 need to bump the helm chart version also