### PR TITLE
feat(httpd) allow using subdir for the htdocs volume mount

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 1.2.2
+version: 1.3.0
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/deployment.yaml
+++ b/charts/httpd/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
               readOnly: true
             - name: html
               mountPath: /usr/local/apache2/htdocs
+              {{- with .Values.repository.subDir }}
+              subPath: {{ . }}
+              {{- end }}
               readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/httpd/tests/custom_values_test.yaml
+++ b/charts/httpd/tests/custom_values_test.yaml
@@ -88,6 +88,9 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[1].readOnly
           value: true
       - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].subPath
+          value: ./foo/
+      - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /usr/local/apache2/htdocs
   - it: should define a managed "html" volume if repository.persistentVolumeClaim.enabled is true

--- a/charts/httpd/tests/defaults_test.yaml
+++ b/charts/httpd/tests/defaults_test.yaml
@@ -62,6 +62,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: html
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1].subPath
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].readOnly
           value: true

--- a/charts/httpd/tests/values/custom.yaml
+++ b/charts/httpd/tests/values/custom.yaml
@@ -2,6 +2,7 @@ image:
   pullPolicy: Never
 repository:
   reuseExistingPersistentVolumeClaim: true
+  subDir: ./foo/
 ingress:
   enabled: true
   hosts:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR allows the chart to mount the `htdocs` directory from a sub directory in the persistent volume.


- Unit tests added
- Tested with success with an emptyDir on a local k3d ephemeral cluster
- Tested with success by installing a new HTTPD chart using a subdir on production (with the Azure File storage created in https://github.com/jenkins-infra/azure/pull/840