### PR TITLE
 fix(httpd) restrict cronjob resources name to 52 chars. max. 

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 1.3.0
+version: 1.3.1
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/_helpers.tpl
+++ b/charts/httpd/templates/_helpers.tpl
@@ -25,6 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Must not be longer than 52 characters!
+*/}}
+{{- define "httpd.restart-fullname" -}}
+{{- printf "%s-%s" (include "httpd.fullname" . | trunc 33 | trimSuffix "-") "restart-deployment" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "httpd.chart" -}}

--- a/charts/httpd/templates/httpdRestart.yaml
+++ b/charts/httpd/templates/httpdRestart.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "httpd.fullname" . }}-restart-deployment
+  name: {{ include "httpd.restart-fullname" . }}
   labels:
 {{ include "httpd.labels" . | indent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "httpd.fullname" . }}-restart-deployment
+  name: {{ include "httpd.restart-fullname" . }}
   labels:
 {{ include "httpd.labels" . | indent 4 }}
 rules:
@@ -21,19 +21,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "httpd.fullname" . }}-restart-deployment
+  name: {{ include "httpd.restart-fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "httpd.fullname" . }}-restart-deployment
+  name: {{ include "httpd.restart-fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "httpd.fullname" . }}-restart-deployment
+    name: {{ include "httpd.restart-fullname" . }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "httpd.fullname" . }}-restart-deployment
+  name: {{ include "httpd.restart-fullname" . }}
   labels:
 {{ include "httpd.labels" . | indent 4 }}
 spec:
@@ -43,7 +43,7 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: {{ include "httpd.fullname" . }}-restart-deployment
+          serviceAccountName: {{ include "httpd.restart-fullname" . }}
           restartPolicy: Never
           containers:
             - name: kubectl-httpdrestart

--- a/charts/httpd/tests/custom_values_test.yaml
+++ b/charts/httpd/tests/custom_values_test.yaml
@@ -181,14 +181,30 @@ tests:
       - isKind:
           of: ServiceAccount
         documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: updates-jenkins-io-httpd-unsecure-restart-deployment
+        documentIndex: 0
       - isKind:
           of: Role
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: updates-jenkins-io-httpd-unsecure-restart-deployment
         documentIndex: 1
       - isKind:
           of: RoleBinding
         documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: updates-jenkins-io-httpd-unsecure-restart-deployment
+        documentIndex: 2
       - isKind:
           of: CronJob
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: updates-jenkins-io-httpd-unsecure-restart-deployment
         documentIndex: 3
       - equal:
           path: spec.schedule

--- a/charts/httpd/tests/values/custom.yaml
+++ b/charts/httpd/tests/values/custom.yaml
@@ -1,3 +1,4 @@
+fullnameOverride: updates-jenkins-io-httpd-unsecured
 image:
   pullPolicy: Never
 repository:


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/helm-charts/issues/1356

Tested with success in a local k3d cluster