### PR TITLE
feat(httpd) disable `EnableSendfile` as document root is on the network

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 1.4.0
+version: 1.5.0
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 1.5.0
+version: 1.4.1
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/configmap.yaml
+++ b/charts/httpd/templates/configmap.yaml
@@ -478,8 +478,9 @@ data:
     # broken on your system.
     # Defaults: EnableMMAP On, EnableSendfile Off
     #
+    # Both disabled as the chart specifies a data volume (most probably network based) for htdocs
     EnableMMAP off
-    #EnableSendfile on
+    EnableSendfile off
 
     # Supplemental configuration
     #


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4312#issuecomment-2380584671

This PR ensure send file is disabled as the `htdocs` is mounted on the network.

HTTPD configuration tells us it's disabled by default but better safe than sorry + explicit disabling is safer for maintenance.