### PR TITLE
feat(jenkins-jobs) allow disabling the GitHub Notifications

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Jenkins Infra Team <jenkins-infra-team@googlegroups.com>
 name: jenkins-jobs
-version: 2.2.1
+version: 2.3.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
@@ -32,12 +32,13 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
               name({{ .githubCheckName | default "jenkins" | squote }})
     {{- if empty .enableGitHubChecks }}
               skip(true)
+              skipProgressUpdates(true)
     {{- else }}
               skip({{ not .enableGitHubChecks }})
+              skipProgressUpdates({{ not .enableGitHubChecks }})
     {{- end }}
               // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
               skipNotifications(false)
-              skipProgressUpdates(false)
               // Default value: false. Warning: risk of secret leak in console if the build fails
               // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
               suppressLogs(true)

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
@@ -38,7 +38,11 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
               skipProgressUpdates({{ not .enableGitHubChecks }})
     {{- end }}
               // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+    {{- if empty .disableGitHubNotifications }}
               skipNotifications(false)
+    {{- else }}
+              skipNotifications({{ .disableGitHubNotifications }})
+    {{- end }}
               // Default value: false. Warning: risk of secret leak in console if the build fails
               // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
               suppressLogs(true)

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -38,9 +38,9 @@ tests:
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
                                 skip(true)
+                                skipProgressUpdates(true)
                                 // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
                                 skipNotifications(false)
-                                skipProgressUpdates(false)
                                 // Default value: false. Warning: risk of secret leak in console if the build fails
                                 // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
                                 suppressLogs(true)
@@ -143,9 +143,9 @@ tests:
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
                                 skip(true)
+                                skipProgressUpdates(true)
                                 // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
                                 skipNotifications(false)
-                                skipProgressUpdates(false)
                                 // Default value: false. Warning: risk of secret leak in console if the build fails
                                 // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
                                 suppressLogs(true)
@@ -248,9 +248,9 @@ tests:
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('jenkins')
                                 skip(true)
+                                skipProgressUpdates(true)
                                 // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
                                 skipNotifications(false)
-                                skipProgressUpdates(false)
                                 // Default value: false. Warning: risk of secret leak in console if the build fails
                                 // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
                                 suppressLogs(true)
@@ -353,9 +353,9 @@ tests:
                                 // Note: changing this name might have impact on github branch protections if they specify status names
                                 name('untrusted-ci')
                                 skip(false)
+                                skipProgressUpdates(false)
                                 // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
                                 skipNotifications(false)
-                                skipProgressUpdates(false)
                                 // Default value: false. Warning: risk of secret leak in console if the build fails
                                 // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
                                 suppressLogs(true)

--- a/charts/jenkins-jobs/values.yaml
+++ b/charts/jenkins-jobs/values.yaml
@@ -34,6 +34,7 @@ jobsDefinition: {}
 #       multibranchJobC: ## Default to kind: multibranchJob
 #         name: Job C
 #         enableGitHubChecks: true
+#         disableGitHubNotifications: true
 #         githubCheckName: RogerRoger
 #          enableGitHubChecks: true
 #          allowUntrustedChanges: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4355#issuecomment-2488678996

This PR introduces 2 changes on the chart:

- A bugfix (we expect progress updates to be disabled when GH status checks are disabled
- A new feature: allow disabling the GitHub Notifications at all