### PR TITLE
fix(rsyncd) service: do not specify an empty 'loadBalancerSourceRanges' when using a LB with no whiteliste specified

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 2.0.1
+version: 2.0.2
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/templates/service.yaml
+++ b/charts/rsyncd/templates/service.yaml
@@ -11,12 +11,14 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
-  {{- with .Values.service.LoadBalancerIP }}
+    {{- with .Values.service.LoadBalancerIP }}
   loadBalancerIP: {{ . }}
-  {{- end }}
+    {{- end }}
+    {{- with .Values.service.whitelisted_sources }}
   loadBalancerSourceRanges:
-    {{- range .Values.service.whitelisted_sources }}
+      {{- range . }}
     - {{ . | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   ports:


### PR DESCRIPTION
Minor change to avoid warning when creating an Azure PLS