### PR TITLE
fix(rsyncd) increase helath probes failures threshold for SSHD

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 2.0.2
+version: 2.0.3
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           {{- if eq .Values.configuration.rsyncd_daemon "sshd" }}
               - sshd
             initialDelaySeconds: 10
+            failureThreshold: 15
           {{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
               - rsync
             initialDelaySeconds: 5
@@ -76,6 +77,7 @@ spec:
               - test -f /home/rsyncd/run/{{ .Values.configuration.rsyncd_daemon }}.pid
             {{- if eq .Values.configuration.rsyncd_daemon "sshd" }}
             initialDelaySeconds: 10
+            failureThreshold: 15
             {{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
             initialDelaySeconds: 5
             {{- end }}


### PR DESCRIPTION
This PR fixes the health probes for `rsyncd` which is failing its initial deployment due to host key generation taking more time than expected