### PR TITLE
breaking(mirrorbits-parent) remove child chart 'rsyncd'

### DIFF
--- a/charts/mirrorbits-parent/Chart.lock
+++ b/charts/mirrorbits-parent/Chart.lock
@@ -5,8 +5,5 @@ dependencies:
 - name: httpd
   repository: https://jenkins-infra.github.io/helm-charts
   version: 1.4.1
-- name: rsyncd
-  repository: https://jenkins-infra.github.io/helm-charts
-  version: 2.0.3
 digest: sha256:0c9bb40b9dd85ef850004477c76796f065c8adf8a6bb46f4a22a553da6d05d84
 generated: "2024-11-25T13:49:30.465307716Z"

--- a/charts/mirrorbits-parent/Chart.yaml
+++ b/charts/mirrorbits-parent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mirrorbits-parent
 description: A mirrorbits parent chart for Kubernetes
 type: application
-version: 6.0.33
+version: 7.0.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team
@@ -15,7 +15,3 @@ dependencies:
   condition: httpd.enabled
   repository: https://jenkins-infra.github.io/helm-charts
   version: 1.4.1
-- name: rsyncd
-  condition: rsyncd.enabled
-  repository: https://jenkins-infra.github.io/helm-charts
-  version: 2.0.3

--- a/charts/mirrorbits-parent/README.md
+++ b/charts/mirrorbits-parent/README.md
@@ -4,7 +4,6 @@ This chart allows to deploys up to three services:
 
 * [mirrorbits](https://github.com/etix/mirrorbits) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/mirrorbits>
 * [httpd (Apache2)](https://httpd.apache.org/) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/httpd>
-* [rsyncd](https://linux.die.net/man/1/rsync) through the subchart <https://github.com/jenkins-infra/helm-charts/tree/main/charts/rsyncd>
 
 The goal is to deploy an "HTTP redirector" service centered on [mirrorbits](https://github.com/etix/mirrorbits) and/or a Jenkins download mirror.
 

--- a/charts/mirrorbits-parent/values.yaml
+++ b/charts/mirrorbits-parent/values.yaml
@@ -91,5 +91,3 @@ mirrorbits:
 httpd:
   enabled: false
   backendServiceNameTpl: '{{ include "httpd.fullname" (index $.Subcharts "httpd")}}'
-rsyncd:
-  enabled: false

--- a/updatecli/updatecli.d/mirrorbits-parent.yaml
+++ b/updatecli/updatecli.d/mirrorbits-parent.yaml
@@ -25,12 +25,6 @@ sources:
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: httpd
-  lastRsyncdChartVersion:
-    kind: helmchart
-    name: get last chart version
-    spec:
-      url: https://jenkins-infra.github.io/helm-charts
-      name: rsyncd
 
 targets:
   updateMirrorbits:
@@ -53,16 +47,6 @@ targets:
       key: $.dependencies[1].version
       versionincrement: patch
     scmid: default
-  updateRsyncd:
-    name: Update rsyncd subchart version
-    sourceid: lastRsyncdChartVersion
-    kind: helmchart
-    spec:
-      name: charts/mirrorbits-parent
-      file: Chart.yaml
-      key: $.dependencies[2].version
-      versionincrement: patch
-    scmid: default
 
 actions:
   default:
@@ -74,4 +58,3 @@ actions:
         - dependencies
         - mirrorbits
         - httpd
-        - rsyncd


### PR DESCRIPTION
This PR removes the `rsyncd` child chart as we don't need it anymore since we [added a distinct rsync installation](https://github.com/jenkins-infra/helpdesk/issues/2649) for updates.jenkins.io. 

It avoids unused PR such as https://github.com/jenkins-infra/helm-charts/pull/1441