### PR TITLE
feat(mirrorbits) allow to mount a PVC with a subdir option

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.4.10
+version: 5.5.0
 appVersion: "v0.5.1"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
             - name: data
               mountPath: {{ .Values.config.repository }}
               readOnly: true
+              {{- with .Values.repository.subDir }}
+              subDir: {{ . }}
+              {{- end }}
             - name: tmpdir
               mountPath: /tmp
               readOnly: false


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402

This PR introduces the `subPath` mount option so we can centralize to only a single NFS PVC if needed