### PR TITLE
feat(rsyncd) allow specifying path to existing host keys through `configuration.sshd.persistentHostKeys`

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 2.0.5
+version: 2.1.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -39,13 +39,19 @@ spec:
               value: "{{ .Values.configuration.rsyncd_daemon }}"
             - name: {{ upper .Values.configuration.rsyncd_daemon }}_PORT
               value: "{{ include "rsyncd.port" . }}"
-          {{- if and .Values.configuration.sshd .Values.configuration.sshd.public_key }}
+          {{- if .Values.configuration.sshd }}
+            {{- with .Values.configuration.sshd.public_key }}
             - name: SSHD_PUBLIC_KEY
-              value: "{{ .Values.configuration.sshd.public_key }}"
-          {{- end }}
-          {{- if and .Values.configuration.sshd .Values.configuration.sshd.log_level }}
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.configuration.sshd.log_level }}
             - name: SSHD_LOG_LEVEL
-              value: "{{ .Values.configuration.sshd.log_level }}"
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.configuration.sshd.persistentHostKeys }}
+            - name: HOST_KEYS_SRC_DIR
+              value: "{{ . }}"
+            {{- end }}
           {{- end }}
           ports:
             - name: {{ .Values.configuration.rsyncd_daemon }}
@@ -109,7 +115,7 @@ spec:
             - name: datadir-{{ .name }}
               mountPath: {{ .path }}
               readOnly: {{ eq (toString .writeEnabled) "true" | ternary "false" "true" }}
-            {{- end }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/rsyncd/tests/custom_values_sshd_test.yaml
+++ b/charts/rsyncd/tests/custom_values_sshd_test.yaml
@@ -87,6 +87,24 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].value
           value: "2222"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: SSHD_PUBLIC_KEY
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: "ssh-rsa AAAAAAAA=="
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: SSHD_LOG_LEVEL
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: DEBUG3
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: HOST_KEYS_SRC_DIR
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: "/foo/keys"
       # Custom container resources
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu

--- a/charts/rsyncd/tests/values/custom_sshd.yaml
+++ b/charts/rsyncd/tests/values/custom_sshd.yaml
@@ -31,6 +31,8 @@ configuration:
   rsyncd_daemon: sshd
   sshd:
     public_key: "ssh-rsa AAAAAAAA=="
+    log_level: DEBUG3
+    persistentHostKeys: /foo/keys
   components:
     - name: jenkins
       path: /rsyncd/data/jenkins


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402#issuecomment-2505362943

> Each time the `rsyncd` (with sshd enabled) restarts on a new node, it regenerates the SSHD host keys which fails any new connections.

This PR updates the chart (and entrypoint - ref. https://github.com/jenkins-infra/docker-rsyncd/pull/29) to allow specifying a directory in which to get existing SSH host keys at restart through the `configuration.sshd.persistentHostKeys` value.

Tested locally on k3s by using a component's specified PVC with a subdir:

- Installed the chart one time without the persistence key enabled
- Copied the generated keys in the PVC's subdir
- Ran one time a rsync command: it asked the usual "yes/no" question about host fingerprint. Accepted tyo have my known_host up to date.
- Uninstall the chart (except the PVC)
- Re-install with configuration.sshd.persistentHostKeys specified to the PVC's subdir
- Ran a second time the rsync command: no host fingerprint change detected!
