### PR TITLE
feat!(rsyncd) deprecate `configuration.sshd.hostKeys` and all "snake cased" values and replace them by "camel cased" values

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 2.1.0
+version: 3.0.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/templates/_helpers.tpl
+++ b/charts/rsyncd/templates/_helpers.tpl
@@ -67,9 +67,9 @@ emptyDir: {}
 {{/* Overrides defaults if the top level `port` value exists */}}
 {{- if .Values.port -}}
 {{ .Values.port }}
-{{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" -}}
+{{- else if eq .Values.configuration.rsyncdDaemon "rsyncd" -}}
 1873
-{{- else if eq .Values.configuration.rsyncd_daemon "sshd" -}}
+{{- else if eq .Values.configuration.rsyncdDaemon "sshd" -}}
 2222
 {{- end -}}
 {{- end -}}
@@ -79,9 +79,9 @@ emptyDir: {}
 {{/* Overrides defaults if the `service.port` value exists */}}
 {{- if .Values.service.port -}}
 {{ .Values.service.port }}
-{{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" -}}
+{{- else if eq .Values.configuration.rsyncdDaemon "rsyncd" -}}
 873
-{{- else if eq .Values.configuration.rsyncd_daemon "sshd" -}}
+{{- else if eq .Values.configuration.rsyncdDaemon "sshd" -}}
 22
 {{- end -}}
 {{- end -}}

--- a/charts/rsyncd/templates/configmap.rsyncd-conf.yaml
+++ b/charts/rsyncd/templates/configmap.rsyncd-conf.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
+{{- if eq .Values.configuration.rsyncdDaemon "rsyncd" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -36,11 +36,11 @@ spec:
           {{- end }}
           env:
             - name: RSYNCD_DAEMON
-              value: "{{ .Values.configuration.rsyncd_daemon }}"
-            - name: {{ upper .Values.configuration.rsyncd_daemon }}_PORT
+              value: "{{ .Values.configuration.rsyncdDaemon }}"
+            - name: {{ upper .Values.configuration.rsyncdDaemon }}_PORT
               value: "{{ include "rsyncd.port" . }}"
           {{- if .Values.configuration.sshd }}
-            {{- with .Values.configuration.sshd.public_key }}
+            {{- with .Values.configuration.sshd.publicKey }}
             - name: SSHD_PUBLIC_KEY
               value: "{{ . }}"
             {{- end }}
@@ -48,13 +48,9 @@ spec:
             - name: SSHD_LOG_LEVEL
               value: "{{ . }}"
             {{- end }}
-            {{- with .Values.configuration.sshd.persistentHostKeys }}
-            - name: HOST_KEYS_SRC_DIR
-              value: "{{ . }}"
-            {{- end }}
           {{- end }}
           ports:
-            - name: {{ .Values.configuration.rsyncd_daemon }}
+            - name: {{ .Values.configuration.rsyncdDaemon }}
               containerPort: {{ include "rsyncd.port" . }}
               protocol: TCP
           livenessProbe:
@@ -64,11 +60,11 @@ spec:
             exec:
               command:
               - pgrep
-          {{- if eq .Values.configuration.rsyncd_daemon "sshd" }}
+          {{- if eq .Values.configuration.rsyncdDaemon "sshd" }}
               - sshd
             initialDelaySeconds: 10
             failureThreshold: 15
-          {{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
+          {{- else if eq .Values.configuration.rsyncdDaemon "rsyncd" }}
               - rsync
             initialDelaySeconds: 5
           {{- end }}
@@ -80,11 +76,11 @@ spec:
               command:
               - sh
               - -c
-              - test -f /home/rsyncd/run/{{ .Values.configuration.rsyncd_daemon }}.pid
-            {{- if eq .Values.configuration.rsyncd_daemon "sshd" }}
+              - test -f /home/rsyncd/run/{{ .Values.configuration.rsyncdDaemon }}.pid
+            {{- if eq .Values.configuration.rsyncdDaemon "sshd" }}
             initialDelaySeconds: 10
             failureThreshold: 15
-            {{- else if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
+            {{- else if eq .Values.configuration.rsyncdDaemon "rsyncd" }}
             initialDelaySeconds: 5
             {{- end }}
             periodSeconds: 5
@@ -99,7 +95,7 @@ spec:
             - name: ramfs
               mountPath: /home/rsyncd/run
               subPath: run
-          {{- if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
+          {{- if eq .Values.configuration.rsyncdDaemon "rsyncd" }}
             - name: rsyncd-conf
               mountPath: /home/rsyncd/etc/rsyncd.d/rsyncd.inc
               readOnly: true # Default for configmaps
@@ -115,6 +111,13 @@ spec:
             - name: datadir-{{ .name }}
               mountPath: {{ .path }}
               readOnly: {{ eq (toString .writeEnabled) "true" | ternary "false" "true" }}
+          {{- end }}
+          {{- if .Values.configuration.sshd }}
+            {{- if .Values.configuration.sshd.hostKeys }}
+            - name: hostkeys
+              mountPath: /home/rsyncd/etc/keys
+              readOnly: true
+            {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -133,7 +136,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 32Mi
-    {{- if eq .Values.configuration.rsyncd_daemon "rsyncd" }}
+    {{- if eq .Values.configuration.rsyncdDaemon "rsyncd" }}
         - name: rsyncd-conf
           configMap:
             name: {{ include "rsyncd.fullname" . }}-conf
@@ -141,4 +144,9 @@ spec:
     {{- range .Values.configuration.components }}
         - name: datadir-{{ .name }}
       {{- include "rsyncd.datadir-volumedefinition" (dict "currentRsyncComponent" . "rootContext" $) | nindent 10 }}
+    {{- end }}
+    {{- if and .Values.configuration.sshd .Values.configuration.sshd.hostKeys }}
+        - name: hostkeys
+          secret:
+            secretName: {{ include "rsyncd.fullname" . }}-hostkeys
     {{- end }}

--- a/charts/rsyncd/templates/secrets.yaml
+++ b/charts/rsyncd/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.configuration.sshd .Values.configuration.sshd.hostKeys }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rsyncd.fullname" . }}-hostkeys
+  labels:
+{{ include "rsyncd.labels" . | indent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.configuration.sshd.hostKeys }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/rsyncd/templates/service.yaml
+++ b/charts/rsyncd/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     {{- with .Values.service.LoadBalancerIP }}
   loadBalancerIP: {{ . }}
     {{- end }}
-    {{- with .Values.service.whitelisted_sources }}
+    {{- with .Values.service.whitelistedSources }}
   loadBalancerSourceRanges:
       {{- range . }}
     - {{ . | quote }}
@@ -25,7 +25,7 @@ spec:
     - port: {{ include "rsyncd.service.port" . }}
       targetPort: {{ include "rsyncd.port" . }}
       protocol: TCP
-      name: {{ .Values.configuration.rsyncd_daemon }}
+      name: {{ .Values.configuration.rsyncdDaemon }}
   selector:
     app.kubernetes.io/name: {{ include "rsyncd.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/rsyncd/tests/custom_values_rsyncd_test.yaml
+++ b/charts/rsyncd/tests/custom_values_rsyncd_test.yaml
@@ -259,3 +259,8 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 1111
+  - it: should not define any Secret
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/rsyncd/tests/custom_values_sshd_test.yaml
+++ b/charts/rsyncd/tests/custom_values_sshd_test.yaml
@@ -99,12 +99,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[3].value
           value: DEBUG3
-      - equal:
-          path: spec.template.spec.containers[0].env[4].name
-          value: HOST_KEYS_SRC_DIR
-      - equal:
-          path: spec.template.spec.containers[0].env[4].value
-          value: "/foo/keys"
+      - notExists:
+          path: spec.template.spec.containers[0].env[4]
       # Custom container resources
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -171,6 +167,23 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].readOnly
           value: false
+      - equal:
+          path: spec.template.spec.volumes[3].name
+          value: hostkeys
+      - equal:
+          path: spec.template.spec.volumes[3].secret.secretName
+          value: RELEASE-NAME-rsyncd-hostkeys
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: hostkeys
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
+          value: /home/rsyncd/etc/keys
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[4].subPath
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].readOnly
+          value: true
   - it: should not create any config map
     template: configmap.rsyncd-conf.yaml
     asserts:
@@ -226,3 +239,20 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 1111
+  - it: should define a Secret holding provided host keys
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rsyncd-hostkeys
+      - equal:
+          path: type
+          value: Opaque
+      - isNotNullOrEmpty:
+          path: data.ssh_host_dsa_key
+      - isNotNullOrEmpty:
+          path: data["ssh_host_dsa_key.pub"]

--- a/charts/rsyncd/tests/defaults_test.yaml
+++ b/charts/rsyncd/tests/defaults_test.yaml
@@ -184,3 +184,8 @@ tests:
           value: "RELEASE-NAME"
       - notExists:
           path: metadata.annotations
+  - it: should not define any Secret
+    template: secrets.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/rsyncd/tests/values/custom_rsyncd.yaml
+++ b/charts/rsyncd/tests/values/custom_rsyncd.yaml
@@ -23,7 +23,7 @@ port: 9999
 service:
   type: LoadBalancer
   LoadBalancerIP: 1.2.3.4
-  whitelisted_sources:
+  whitelistedSources:
     - 52.167.253.43/32
     - 52.202.51.185/32
   annotations:

--- a/charts/rsyncd/tests/values/custom_sshd.yaml
+++ b/charts/rsyncd/tests/values/custom_sshd.yaml
@@ -22,17 +22,28 @@ resources:
 service:
   type: LoadBalancer
   LoadBalancerIP: 1.2.3.4
-  whitelisted_sources:
+  whitelistedSources:
     - 52.167.253.43/32
     - 52.202.51.185/32
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 configuration:
-  rsyncd_daemon: sshd
+  rsyncdDaemon: sshd
   sshd:
-    public_key: "ssh-rsa AAAAAAAA=="
+    publicKey: "ssh-rsa AAAAAAAA=="
     log_level: DEBUG3
-    persistentHostKeys: /foo/keys
+    hostKeys:
+      ssh_host_dsa_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEogIBAAKCAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzI
+        w+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoP
+        kcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2
+        DUMMY KEY
+        kda/AoGANWrLCz708y7VYgAtW2Uf1DPOIYMdvo6fxIB5i9ZfISgcJ/bbCUkFrhoH
+        +vq/5CIWxCPp0f85R4qxxQ5ihxJ0YDQT9Jpx4TMss4PSavPaBH3RXow5Ohe+bYoQ
+        NE5OgEXk2wVfZczCZpigBKbKZHNYcelXtTt/nP3rsCuGcM4h53s=
+        -----END RSA PRIVATE KEY-----
+      ssh_host_dsa_key.pub: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ=="
   components:
     - name: jenkins
       path: /rsyncd/data/jenkins

--- a/charts/rsyncd/values.yaml
+++ b/charts/rsyncd/values.yaml
@@ -27,7 +27,7 @@ service:
   ## Custom port published by the "Service" if you don't want the standard RsyncD 873 (or SSHD 22)
   # port: 873
   # LoadBalancerIP: 1.2.3.4
-  whitelisted_sources: []
+  whitelistedSources: []
   # - 52.167.253.43/32
   # - 52.202.51.185/32
 resources: {}
@@ -46,7 +46,7 @@ tolerations: []
 affinity: {}
 configuration:
   ## Specify the Daemon providing rsync service capability: 'rsyncd' (default) or 'sshd'
-  rsyncd_daemon: rsyncd
+  rsyncdDaemon: rsyncd
   rsyncd:
     ## Uncomment to specify a list of "rsyncd" components (rsync://server.name:873/COMPONENT)
     components: []
@@ -55,6 +55,12 @@ configuration:
     #     comment: "Jenkins Read-Only Mirror"
     #     volume:
     #       emptyDir: {}
-  ## Set up the SSHD service (when `configuration.rsyncd_daemon` equals 'sshd')
+  ## Set up the SSHD service (when `configuration.rsyncdDaemon` equals 'sshd')
   # sshd:
-  #   public_key: "ssh-rsa XXXXX"
+  #   # sepcify the publickey to use for the user 'rsyncd'
+  #   publicKey: "ssh-rsa XXXXX"
+  #   # Specify the SSHD persistent host keys
+  #   hostKeys:
+  #     ssh_host_dsa_key: ""
+  #     ssh_host_dsa_key.pub: ""
+  #     # ...


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402

New feature: specify hostkeys through `configuration.sshd.hostKeys` as individual "files" (mounted as secret)

BREAKING CHANGE: remove `configuration.sshd.persistentHostKeys`
BREAKING CHANGE: Replace `configuration.sshd.rsyncd_daemon` by `configuration.sshd.rsyncdDaemon`
BREAKING CHANGE: Replace `configuration.sshd.public_key` by `configuration.sshd.publicKey`
BREAKING CHANGE: Replace `service.whitelisted_sources` by `service.whitelistedSources`