### PR TITLE
feat(rsyncd) allow specifying a sub directory for each component to mount (instead of the root)

### DIFF
--- a/charts/rsyncd/Chart.yaml
+++ b/charts/rsyncd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: rsyncd helm chart for Kubernetes
 name: rsyncd
-version: 3.0.0
+version: 3.1.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/rsyncd/templates/deployment.yaml
+++ b/charts/rsyncd/templates/deployment.yaml
@@ -111,6 +111,9 @@ spec:
             - name: datadir-{{ .name }}
               mountPath: {{ .path }}
               readOnly: {{ eq (toString .writeEnabled) "true" | ternary "false" "true" }}
+              {{- with .volumeSubDir }}
+              subPath: {{ . }}
+              {{- end }}
           {{- end }}
           {{- if .Values.configuration.sshd }}
             {{- if .Values.configuration.sshd.hostKeys }}

--- a/charts/rsyncd/tests/custom_values_rsyncd_test.yaml
+++ b/charts/rsyncd/tests/custom_values_rsyncd_test.yaml
@@ -185,8 +185,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[6].mountPath
           value: /tmp/hudson
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].volumeMounts[6].subPath
+          value: ./foo/
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[6].readOnly
           value: false

--- a/charts/rsyncd/tests/custom_values_sshd_test.yaml
+++ b/charts/rsyncd/tests/custom_values_sshd_test.yaml
@@ -162,8 +162,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].mountPath
           value: /tmp/hudson
-      - notExists:
+      - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].subPath
+          value: ./foo/
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].readOnly
           value: false

--- a/charts/rsyncd/tests/values/custom_rsyncd.yaml
+++ b/charts/rsyncd/tests/values/custom_rsyncd.yaml
@@ -40,4 +40,5 @@ configuration:
       path: /tmp/hudson
       comment: "Hudson Read-Only Mirror"
       volumeTpl: "another-vol"
+      volumeSubDir: ./foo/
       writeEnabled: true

--- a/charts/rsyncd/tests/values/custom_sshd.yaml
+++ b/charts/rsyncd/tests/values/custom_sshd.yaml
@@ -55,4 +55,5 @@ configuration:
       path: /tmp/hudson
       comment: "Hudson Read-Only Mirror"
       volumeTpl: "another-vol"
+      volumeSubDir: ./foo/
       writeEnabled: true


### PR DESCRIPTION
…