### PR TITLE
feat(geoipupdate): remove `update_frequency` parameter not used in cronjob

### DIFF
--- a/charts/geoipupdates/Chart.yaml
+++ b/charts/geoipupdates/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: MaxMind GeoIP database updater
 name: geoipupdates
-version: 2.0.0
+version: 2.0.1
 appVersion: "v7.1.0"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/geoipupdates/templates/cronjob.yaml
+++ b/charts/geoipupdates/templates/cronjob.yaml
@@ -43,10 +43,6 @@ spec:
                 - name: GEOIPUPDATE_EDITION_IDS
                   value: {{ . }}
                 {{- end }}
-                {{- with .Values.geoipupdate.update_frequency }}
-                - name: GEOIPUPDATE_FREQUENCY
-                  value: {{ . | quote }}
-                {{- end }}
                 {{- with .Values.geoipupdate.storage_name }}
                 - name: STORAGE_NAME
                   value: {{ . }}

--- a/charts/geoipupdates/tests/custom_values_test.yaml
+++ b/charts/geoipupdates/tests/custom_values_test.yaml
@@ -41,19 +41,13 @@ tests:
           value: alleditions
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].env[2].name
-          value: GEOIPUPDATE_FREQUENCY
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[2].value
-          value: "74"
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[3].name
           value: STORAGE_NAME
       - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[3].value
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[2].value
           value: mystoragename
       - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[4].name
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[3].name
           value: STORAGE_FILESHARE
       - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[4].value
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[3].value
           value: myfileshare

--- a/charts/geoipupdates/tests/defaults_test.yaml
+++ b/charts/geoipupdates/tests/defaults_test.yaml
@@ -41,13 +41,7 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].env[1].value
           value: GeoLite2-ASN GeoLite2-City GeoLite2-Country
-      - equal:
+      - notExists:
           path: spec.jobTemplate.spec.template.spec.containers[0].env[2].name
-          value: GEOIPUPDATE_FREQUENCY
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[2].value
-          value: "24"
       - notExists:
           path: spec.jobTemplate.spec.template.spec.containers[0].env[3].name
-      - notExists:
-          path: spec.jobTemplate.spec.template.spec.containers[0].env[4].name

--- a/charts/geoipupdates/tests/values/custom_geoipupdater.yaml
+++ b/charts/geoipupdates/tests/values/custom_geoipupdater.yaml
@@ -6,7 +6,6 @@ geoipupdate:
   fileshare_client_secret: "clientsecret"
   fileshare_tenant_id: "tenantid"
   editions: "alleditions"
-  update_frequency: 74
   storage_name: "mystoragename"
   storage_fileshare: "myfileshare"
   cron: '0 6 * * *' # default to every day at 6AM

--- a/charts/geoipupdates/values.yaml
+++ b/charts/geoipupdates/values.yaml
@@ -13,7 +13,6 @@ geoipupdate:
   fileshare_client_secret: ""
   fileshare_tenant_id: ""
   editions: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
-  update_frequency: 24
   storage_name: ""
   storage_fileshare: ""
   cron: '0 4 * * *' # default to every day at 4AM


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4436

removing `update_frequency` useless in cronjob