### PR TITLE
feat(geoipupdates): rbac enhancement to allow rollout restart

### DIFF
--- a/charts/geoipupdates/templates/rbac.yaml
+++ b/charts/geoipupdates/templates/rbac.yaml
@@ -16,6 +16,10 @@ rules:
     resources: ["pods"]
     resourceNames: [{{ include "geoipupdate.fullname" . }}]
     verbs: ["get", "read", "list", "watch", "create", "patch", "replace", "delete"]
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["updates-jenkins-io", "get-jenkins-io"]
+    verbs: ["get", "patch", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4441#issuecomment-2530708344
and with https://github.com/jenkins-infra/docker-geoipupdate/pull/20

allow the cronjob to perform a geoipupdate AND a rollout restart of mirrorbits instances.