### PR TITLE
Add directive 'proxy_ssl_server_name on' by default

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.6.2
+version: 1.6.3

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -34,6 +34,10 @@ data:
 
     # Specify HTTP code of responses to cache
     proxy_cache_valid {{ .Values.proxy.proxyCacheValidCode }} {{ .Values.proxy.proxyCacheValidCodeDuration }};
+
+    # Set proxy_ssl_server_name to ensure that the server name is passed to the upstream
+    proxy_ssl_server_name on;  # Default for all locations and servers
+
   vhost-proxy.conf: |
     include /etc/nginx/conf.d/cache.conf;
 

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -35,8 +35,10 @@ data:
     # Specify HTTP code of responses to cache
     proxy_cache_valid {{ .Values.proxy.proxyCacheValidCode }} {{ .Values.proxy.proxyCacheValidCodeDuration }};
 
+{{- if .Values.proxy.proxySslServerNameEnabled -}}
     # Set proxy_ssl_server_name to ensure that the server name is passed to the upstream
     proxy_ssl_server_name on;  # Default for all locations and servers
+{{- end }}
 
   vhost-proxy.conf: |
     include /etc/nginx/conf.d/cache.conf;

--- a/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
+++ b/charts/artifact-caching-proxy/tests/proxy_cache_config_test.yaml
@@ -18,6 +18,9 @@ tests:
       - matchRegex:
           path: data["proxy-cache.conf"]
           pattern: proxy_cache_valid 200 206 1M;
+      - notMatchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_ssl_server_name on;
       - matchRegex:
           path: data["vhost-proxy.conf"]
           pattern: set \$initial_proxy_location /public;
@@ -42,6 +45,7 @@ tests:
         proxyPass: "repo.jenkins-ci.org"
         proxyCacheValidCode: "201 204"
         proxyCacheValidCodeDuration: "3H"
+        proxySslServerNameEnabled: true
         initialProxyLocationPath: /
         authorizationHeader: "Bearer 123456"
         dnsResolver: 8.8.8.8
@@ -59,6 +63,9 @@ tests:
       - matchRegex:
           path: data["proxy-cache.conf"]
           pattern: proxy_cache_valid 201 204 3H;
+      - matchRegex:
+          path: data["proxy-cache.conf"]
+          pattern: proxy_ssl_server_name on;
       - matchRegex:
           path: data["vhost-proxy.conf"]
           pattern: set \$initial_proxy_location /;

--- a/charts/artifact-caching-proxy/values.yaml
+++ b/charts/artifact-caching-proxy/values.yaml
@@ -86,6 +86,8 @@ proxy:
   # http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_bypass
   proxyBypass:
     enabled: false
+  # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name
+  proxySslServerNameEnabled: false
   # Allows the configuration of the initial proxy location (e.g. setting to '/' will proxy all requests to the upstream)
   initialProxyLocationPath: /public
   # Allows to set the Authorization header to be sent to the upstream, e.g. "Bearer 123"


### PR DESCRIPTION
This PR sets the [proxy_ssl_server_name](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name) to on by default.

Without this, we get an `SSL alert number 40` when trying to proxy the jenkins-updates.cloudbees.com site.

```sh
2025/01/09 09:28:40 [error] 20#20: *43 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::ssl/tls alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 127.0.0.1, server: _, request: "GET /download/plugins/beer/1.0/beer.hpi HTTP/1.1", upstream: "https://18.160.78.88:443/download/plugins/beer/1.0/beer.hpi", host: "127.0.0.1:8080"
2025/01/09 09:28:40 [warn] 20#20: *43 upstream server temporarily disabled while SSL handshaking to upstream, client: 127.0.0.1, server: _, request: "GET /download/plugins/beer/1.0/beer.hpi HTTP/1.1", upstream: "https://18.160.78.88:443/download/plugins/beer/1.0/beer.hpi", host: "127.0.0.1:8080"
```
