### PR TITLE
feat(jenkins-kubernetes-agents) allow specifying groups bound to the RBAC role used by Jenkins

### DIFF
--- a/charts/jenkins-kubernetes-agents/Chart.yaml
+++ b/charts/jenkins-kubernetes-agents/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: jenkins-kubernetes-agents
 description: A Helm chart for using Jenkins Kubernetes agents on a remote cluster
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "0.1.0"

--- a/charts/jenkins-kubernetes-agents/templates/rbac.yaml
+++ b/charts/jenkins-kubernetes-agents/templates/rbac.yaml
@@ -35,3 +35,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "jenkins.serviceAccountName" . }}
   namespace: {{ template "jenkins.serviceAccountNamespace" . }}
+{{ range .Values.groups }}
+- kind: Group
+  name: {{ . }}
+{{- end }}

--- a/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
+++ b/charts/jenkins-kubernetes-agents/tests/custom_values_test.yaml
@@ -140,3 +140,26 @@ tests:
       - equal:
           path: metadata.namespace
           value: tatooine
+
+  - it: Should add groups for access entries in the RoleBinding
+    template: rbac.yaml
+    set:
+      groups:
+        - groupname1
+        - groupname2
+    documentIndex: 1
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: subjects[1].kind
+          value: Group
+      - equal:
+          path: subjects[1].name
+          value: groupname1
+      - equal:
+          path: subjects[2].kind
+          value: Group
+      - equal:
+          path: subjects[2].name
+          value: groupname2

--- a/charts/jenkins-kubernetes-agents/values.yaml
+++ b/charts/jenkins-kubernetes-agents/values.yaml
@@ -9,3 +9,7 @@ imageCredentials:
 #   pods: 30
 ## uncomment to reuse an existing service account
 # existingServiceAccount: jenkins-infra:jenkins-controller
+## Uncomment to add groups for rbac access entries, see https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html
+# groups:
+#   - groupname1
+#   - groupname2


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2573143011
following https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/76 and https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/77
prepare the helm chart to handle the kubernetes groups and allow credential less connexion