### PR TITLE
feat(javadoc) redirect KK github-api javadoc to its new home

### DIFF
--- a/charts/javadoc/Chart.yaml
+++ b/charts/javadoc/Chart.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for javadoc.jenkins.io
-maintainers:
-- name: timja
 name: javadoc
-version: 0.4.4
+version: 0.5.0
+maintainers:
+- email: jenkins-infra-team@googlegroups.com
+  name: Jenkins Infra Team
+  url: https://www.jenkins.io/projects/infrastructure/
+sources:
+- https://github.com/jenkins-infra/helm-charts

--- a/charts/javadoc/templates/nginx-configmap.yaml
+++ b/charts/javadoc/templates/nginx-configmap.yaml
@@ -8,6 +8,12 @@ data:
     server {
       listen       80;
       server_name  localhost;
+
+      # https://github.com/jenkins-infra/helpdesk/issues/4594
+      location /component/github-api {
+        return 308 https://hub4j.github.io/github-api/apidocs/org.kohsuke.github.api/module-summary.html;
+      }
+
       location / {
           root   /usr/share/nginx/html;
           index  index.html index.htm;


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4594

We do not want Jenkins contributors to receive an HTTP/404 errors when trying to get the javadoc for this component.
Let's add a permanent redirect for keeping the user experience.