### PR TITLE
fix(javadoc) remove maintainer from labels as it may contains forbidden chars

### DIFF
--- a/charts/javadoc/Chart.yaml
+++ b/charts/javadoc/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for javadoc.jenkins.io
 name: javadoc
-version: 0.5.0
+version: 0.5.1
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: Jenkins Infra Team

--- a/charts/javadoc/templates/_helpers.tpl
+++ b/charts/javadoc/templates/_helpers.tpl
@@ -49,5 +49,4 @@ helm.sh/chart: {{ include "javadoc.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-jenkins.io/maintainer: {{ (index .Chart.Maintainers 0).Name }}
 {{- end -}}


### PR DESCRIPTION
This PR fixes the deployment error below introduced by https://github.com/jenkins-infra/helm-charts/pull/1592

```
 Error: UPGRADE FAILED: release javadoc failed, and has been rolled back due to atomic being set: cannot patch "javadoc" with kind PodDisruptionBudget: PodDisruptionBudget.policy "javadoc" is invalid: metadata.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "javadoc" with kind ConfigMap: ConfigMap "javadoc" is invalid: metadata.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "javadoc" with kind Service: Service "javadoc" is invalid: metadata.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "javadoc" with kind Deployment: Deployment.apps "javadoc" is invalid: [metadata.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), spec.template.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')] && cannot patch "javadoc" with kind Ingress: Ingress.networking.k8s.io "javadoc" is invalid: metadata.labels: Invalid value: "Jenkins Infra Team": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```