### PR TITLE
fix(maven-cacher) defaults to latest tag

### DIFF
--- a/charts/maven-cacher/Chart.yaml
+++ b/charts/maven-cacher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Maven Cache updater for the *.jenkins.io controllers
 name: maven-cacher
-version: 0.0.1
+version: 0.0.2
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/maven-cacher/values.yaml
+++ b/charts/maven-cacher/values.yaml
@@ -1,7 +1,6 @@
 image:
   repository: jenkinsciinfra/jenkins-agent-ubuntu-22.04
-  # TODO: track with updatecli
-  tag: 2.33.0
+  tag: latest
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 # securityContext:


### PR DESCRIPTION
If we want to pin to a tag, it is in the release (and we will do it there)