### PR TITLE
feat(ldap)!: specify LoadBalancer source list with a map `service.lbAllowSources`

### DIFF
--- a/charts/ldap/Chart.yaml
+++ b/charts/ldap/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for ldap.jenkins.io
 maintainers:
 - name: jenkins-infra-team@googlegroups.com
 name: ldap
-version: 2.0.5
+version: 3.0.0

--- a/charts/ldap/templates/service.yaml
+++ b/charts/ldap/templates/service.yaml
@@ -16,12 +16,14 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
-  {{- if .Values.service.IP }}
-  loadBalancerIP: {{ .Values.service.IP }}
-  {{- end }}
+    {{- with .Values.service.IP }}
+  loadBalancerIP: {{ . }}
+    {{- end }}
+    {{- with .Values.service.lbAllowSources }}
   loadBalancerSourceRanges:
-    {{- range .Values.service.whitelisted_sources }}
-    - {{ . | quote }}
+      {{- range $sourceId, $sourceCIDR := . }}
+    - {{ $sourceCIDR | quote }}
+      {{- end }}
     {{- end }}
   {{- end }}
   ports:

--- a/charts/ldap/tests/custom_values_test.yaml
+++ b/charts/ldap/tests/custom_values_test.yaml
@@ -3,12 +3,10 @@ templates:
   - secret.yaml
   - service.yaml
   - statefulset.yaml
+values:
+  - values/custom.yaml
 tests:
   - it: should create a Secret with the correct value
-    set:
-      ldap:
-        admin:
-          password: name
     template: secret.yaml
     asserts:
       - hasDocuments:
@@ -49,6 +47,9 @@ tests:
     - equal:
         path: spec.loadBalancerIP
         value: 128.129.0.12
+    - equal:
+        path: spec.loadBalancerSourceRanges[0]
+        value: "1.2.3.4"
     - notExists:
         path: metadata.annotations
   - it: should create a custom service of type loadbalancer with modern AKS annotation for public IP
@@ -79,10 +80,6 @@ tests:
         value: myAKSPublicIP
   - it: should create a statefulset with custom settings
     template: statefulset.yaml
-    set:
-      persistence:
-        customBackupClaimName: superBackup
-        customDataClaimName: batData
     asserts:
     - hasDocuments:
         count: 1

--- a/charts/ldap/tests/defaults_values_test.yaml
+++ b/charts/ldap/tests/defaults_values_test.yaml
@@ -44,6 +44,8 @@ tests:
         path: spec.loadBalancerIP
     - notExists:
         path: metadata.annotations
+    - notExists:
+        path: spec.loadBalancerSourceRanges
   - it: should create a statefulset with default settings
     template: statefulset.yaml
     asserts:

--- a/charts/ldap/tests/values/custom.yaml
+++ b/charts/ldap/tests/values/custom.yaml
@@ -1,0 +1,13 @@
+ldap:
+  admin:
+    password: name
+
+service:
+  lbAllowSources:
+    another: 1.2.3.4
+    local: 127.0.0.1
+
+
+persistence:
+  customBackupClaimName: superBackup
+  customDataClaimName: batData

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -47,7 +47,10 @@ securityContext: {}
 service:
   type: LoadBalancer
   #IP: ''
-  whitelisted_sources: []
+  lbAllowSources: {}
+  # lbAllowSources:
+  #   cidr1: "IPv4/32"
+  #   cidr2: "IPv4/32"
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
instead of using a list of string, for easier maintenance (updatecli may track keys easier than moving array targets)

BREAKING CHANGE: Deprecates `service.whitelisted_sources` in favor of `service.lbAllowSources`


Tested manually with https://github.com/jenkins-infra/kubernetes-management/pull/6379. The order changes (as the ` range` helm gotpl function iterates on map with lexicographical order):

```diff
ldap, ldap, Service (v1) has changed:
  # Source: ldap/templates/service.yaml
  apiVersion: v1
  kind: Service
  metadata:
    name: ldap
    labels:
      app.kubernetes.io/name: ldap
-     helm.sh/chart: ldap-2.0.5
+     helm.sh/chart: ldap-3.0.0
      app.kubernetes.io/instance: ldap
      app.kubernetes.io/managed-by: Helm
    annotations:
      service.beta.kubernetes.io/azure-pip-name: ldap-jenkins-io-ipv4
      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
  spec:
    type: LoadBalancer
    loadBalancerSourceRanges:
-     - "20.85.71.108/32"
-     - "20.22.30.9/32"
-     - "20.22.30.74/32"
-     - "20.7.192.189/32"
-     - "10.100.0.0/16"
-     - "73.71.177.172/32"
      - "140.211.15.101/32"
-     - "20.12.27.65/32"
-     - "104.209.128.236/32"
-     - "172.176.126.194/32"
+     - "3.146.166.108/32"
      - "104.209.153.13/32"
-     - "34.211.101.61/32"
-     - "44.240.22.235/32"
-     - "20.22.6.81/32"
-     - "20.65.63.127/32"
      - "18.214.241.149/32"
      - "34.201.191.93/32"
      - "34.233.58.83/32"
      - "54.236.124.56/32"
-     - "3.146.166.108/32"
+     - "44.240.22.235/32"
+     - "34.211.101.61/32"
+     - "172.176.126.194/32"
+     - "20.65.63.127/32"
+     - "20.22.6.81/32"
+     - "20.7.192.189/32"
+     - "20.85.71.108/32"
+     - "20.22.30.9/32"
+     - "20.22.30.74/32"
+     - "10.100.0.0/16"
+     - "20.12.27.65/32"
+     - "73.71.177.172/32"
+     - "104.209.128.236/32"
```