### PR TITLE
feat(ldap) allow specifying a comma-separated list of CIDR for `spec.lbAllowSources`

### DIFF
--- a/charts/ldap/Chart.yaml
+++ b/charts/ldap/Chart.yaml
@@ -3,4 +3,4 @@ description: A Helm chart for ldap.jenkins.io
 maintainers:
 - name: jenkins-infra-team@googlegroups.com
 name: ldap
-version: 3.0.0
+version: 3.1.0

--- a/charts/ldap/templates/service.yaml
+++ b/charts/ldap/templates/service.yaml
@@ -22,7 +22,9 @@ spec:
     {{- with .Values.service.lbAllowSources }}
   loadBalancerSourceRanges:
       {{- range $sourceId, $sourceCIDR := . }}
-    - {{ $sourceCIDR | quote }}
+        {{- range $key, $value := (split "," $sourceCIDR) }}
+    - {{ $value | trim | quote }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/ldap/tests/custom_values_test.yaml
+++ b/charts/ldap/tests/custom_values_test.yaml
@@ -50,6 +50,12 @@ tests:
     - equal:
         path: spec.loadBalancerSourceRanges[0]
         value: "1.2.3.4"
+    - equal:
+        path: spec.loadBalancerSourceRanges[1]
+        value: "127.0.0.1"
+    - equal:
+        path: spec.loadBalancerSourceRanges[2]
+        value: "127.0.0.0/24"
     - notExists:
         path: metadata.annotations
   - it: should create a custom service of type loadbalancer with modern AKS annotation for public IP

--- a/charts/ldap/tests/values/custom.yaml
+++ b/charts/ldap/tests/values/custom.yaml
@@ -5,7 +5,7 @@ ldap:
 service:
   lbAllowSources:
     another: 1.2.3.4
-    local: 127.0.0.1
+    locals: "127.0.0.1, 127.0.0.0/24"
 
 
 persistence:


### PR DESCRIPTION
Following up #1616 , we'll need to provide a list of CIDR for some items.

This change allows specifying the list of CIDR with a in the form of a comma-separated string