### PR TITLE
chore(updatecli): Automatically request reviews from plugin health scoring maintainers

### DIFF
--- a/updatecli/updatecli.d/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/plugin-health-scoring.yaml
@@ -47,6 +47,10 @@ actions:
     scmid: default
     title: Bump `plugin-health-scoring` docker image version to {{ source "latestRelease" }}
     spec:
+      automerged: true
+      reviewers:
+        - alecharp
+        - darinpope
       labels:
         - dependencies
         - plugin-health-scoring


### PR DESCRIPTION
As it is possible to ask UpdateCLI to request review, let's make sure the plugin health scoring maintainers are requested. 
We could have a team in `github/jenkins-infra` about those users but for now direct username should work.