### PR TITLE
feat(plugin-health-score) allow specifying custom annotations instead of unused config checksum

### DIFF
--- a/charts/plugin-health-scoring/Chart.yaml
+++ b/charts/plugin-health-scoring/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 name: plugin-health-scoring
 type: application
-version: 3.0.17
+version: 3.1.0

--- a/charts/plugin-health-scoring/templates/deployment.yaml
+++ b/charts/plugin-health-scoring/templates/deployment.yaml
@@ -15,8 +15,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "plugin-health-scoring.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ print "%v" .Values.secrets | sha256sum }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       automountServiceAccountToken: false
     {{- with .Values.imagePullSecrets }}

--- a/charts/plugin-health-scoring/tests/custom_values_test.yaml
+++ b/charts/plugin-health-scoring/tests/custom_values_test.yaml
@@ -4,39 +4,35 @@ templates:
   - service.yaml
   - ingress.yaml
   - secret.yaml
+values:
+  - values/custom.yaml
 tests:
-  - it: should use custom secrets
-    set:
-      secrets:
-        github0auth: "SuperSecret2022!"
-        database:
-          password: "PleaseDoNotUseWeakPasswords"
+  - it: should generate a deployment with custom setup
+    template: deployment.yaml
     asserts:
       - hasDocuments:
           count: 1
-        template: deployment.yaml
       - isKind:
           of: Deployment
-        template: deployment.yaml
+      - equal:
+          path: spec.template.metadata.annotations["ad.datadoghq.com/phs.logs"]
+          value: |
+            [
+              {"source":"java","service":"RELEASE-NAME"}
+            ]
+  - it: should generate a secret with custom values
+    template: secret.yaml
+    asserts:
       - hasDocuments:
           count: 1
-        template: secret.yaml
       - isKind:
           of: Secret
-        template: secret.yaml
-      # Secret name should not change
       - equal:
           path: metadata.name
           value: RELEASE-NAME-plugin-health-scoring
-        template: secret.yaml
       - equal:
           path: data.databasePassword
           value: UGxlYXNlRG9Ob3RVc2VXZWFrUGFzc3dvcmRz # echo 'UGxlYXNlRG9Ob3RVc2VXZWFrUGFzc3dvcmRz' | base64 -d => 'PleaseDoNotUseWeakPasswords'
-        template: secret.yaml
       - equal:
           path: data.githubAppPrivateKey
           value: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tIGJsYWJsYWJsYWJsYSAtLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS0=
-        template: secret.yaml
-      - isNotEmpty:
-          path: spec.template.metadata.annotations.checksum/config
-        template: deployment.yaml

--- a/charts/plugin-health-scoring/tests/defaults_test.yaml
+++ b/charts/plugin-health-scoring/tests/defaults_test.yaml
@@ -5,33 +5,53 @@ templates:
   - ingress.yaml
   - secret.yaml
 tests:
-  - it: should generate a service and deployment only with default values
+  - it: should generate a deployment with default values
+    template: deployment.yaml
     asserts:
       - hasDocuments:
           count: 1
-        template: deployment.yaml
       - isKind:
           of: Deployment
-        template: deployment.yaml
-      - hasDocuments:
-          count: 1
-        template: service.yaml
-      - isKind:
-          of: Service
-        template: service.yaml
-      - hasDocuments:
-          count: 1
-        template: secret.yaml
-      - isKind:
-          of: Secret
-        template: secret.yaml
-      - hasDocuments:
-          count: 0
-        template: ingress.yaml
       - equal:
           path: metadata.name
           value: RELEASE-NAME-plugin-health-scoring
-        template: deployment.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPDATE_CENTER_CRON
+            value: "0 */15 * * * *"
+      - notExists:
+          path: spec.template.metadata.annotations
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-plugin-health-scoring
+                key: databasePassword
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITHUB_APP_PRIVATE_KEY_PATH
+            value: /mnt/secrets/github/private-key
+  - it: should generate a service with default values
+    template: service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+  - it: should generate a service with default values
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
       - equal:
           path: metadata.name
           value: RELEASE-NAME-plugin-health-scoring
@@ -44,31 +64,8 @@ tests:
           path: data.githubAppPrivateKey
           value: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tIGJsYWJsYWJsYWJsYSAtLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS0=
         template: secret.yaml
-      - equal:
-          path: spec.replicas
-          value: 1
-        template: deployment.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: UPDATE_CENTER_CRON
-            value: "0 */15 * * * *"
-        template: deployment.yaml
-      - isNotEmpty:
-          path: spec.template.metadata.annotations.checksum/config
-        template: deployment.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: RELEASE-NAME-plugin-health-scoring
-                key: databasePassword
-        template: deployment.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: GITHUB_APP_PRIVATE_KEY_PATH
-            value: /mnt/secrets/github/private-key
-        template: deployment.yaml
+  - it: should not deploy any ingress by default
+    template: ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/plugin-health-scoring/tests/values/custom.yaml
+++ b/charts/plugin-health-scoring/tests/values/custom.yaml
@@ -1,0 +1,9 @@
+secrets:
+  github0auth: "SuperSecret2022!"
+  database:
+    password: "PleaseDoNotUseWeakPasswords"
+podAnnotations:
+  ad.datadoghq.com/phs.logs: |
+    [
+      {"source":"java","service":"RELEASE-NAME"}
+    ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4678#issuecomment-2931064411

We need to ensure PHS logs are collected with the proper tags to allow Datadog autodiscovery to work: as such we need to support custom annotations on this deployment (ref. https://docs.datadoghq.com/containers/kubernetes/log/)