### PR TITLE
fix(acp) turn HTTP/403 from backend to HTTP/404 for clients

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.6.6
+version: 1.6.7

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -93,6 +93,8 @@ data:
             proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
 
             proxy_intercept_errors on;
+            # Forbidden (403) resources on the backend should be answered "Not Found" (404) to content Maven
+            error_page 403 =404 /404.html;
             # If the file is not found, then fallback the search in the "non-cached jenkins incrementals" upstream server
             error_page 404 = @fallback_noncached_jenkins_incrementals;
         }
@@ -101,6 +103,8 @@ data:
             proxy_pass          https://$jenkins_repo/incrementals$request_uri;
 
             proxy_intercept_errors on;
+            # Forbidden (403) resources on the backend should be answered "Not Found" (404) to content Maven
+            error_page 403 =404 /404.html;
             # If the file is not found, then fallback the search in the "non-cached maven central" upstream server
             error_page 404 = @fallback_noncached_maven_central;
         }
@@ -110,6 +114,8 @@ data:
 
             # Stop chaining requests
             proxy_intercept_errors off;
+            # Forbidden (403) resources on the backend should be answered "Not Found" (404) to content Maven
+            error_page 403 =404 /404.html;
         }
 
         # Cached requests


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4674#issuecomment-2938881249

Maven expects to receive HTTP/404 if the remote file does not exist on the multiple backends