### PR TITLE
feat(nginx-website) allow specifying custom pod annotations

### DIFF
--- a/charts/nginx-website/Chart.yaml
+++ b/charts/nginx-website/Chart.yaml
@@ -6,4 +6,4 @@ name: nginx-website
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team
-version: 0.3.2
+version: 0.4.0

--- a/charts/nginx-website/templates/deployment.yaml
+++ b/charts/nginx-website/templates/deployment.yaml
@@ -12,8 +12,10 @@ spec:
   template:
     metadata:
       labels: {{ include "nginx-website.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       automountServiceAccountToken: false
     {{- with .Values.imagePullSecrets }}

--- a/charts/nginx-website/tests/custom_values_locations_test.yaml
+++ b/charts/nginx-website/tests/custom_values_locations_test.yaml
@@ -3,7 +3,8 @@ suite: Test with custom values
 templates:
   - nginx-configmap.yaml
 values:
-    - values/custom.yaml
+  - values/custom.yaml
+  - values/custom-locations.yaml
 tests:
   - it: should create a custom nginx locations configuration
     template: nginx-configmap.yaml

--- a/charts/nginx-website/tests/custom_values_test.yaml
+++ b/charts/nginx-website/tests/custom_values_test.yaml
@@ -3,16 +3,9 @@ suite: Test with custom values
 templates:
   - pdb.yaml
   - nginx-configmap.yaml
-set:
-  nginx:
-    serverName: _
-    slashLocation:
-      root: /custom
-      index: custom.html
-      autoindex: "off"
-      tryFiles: $uri /index.html
-  service:
-    port: 8080
+  - deployment.yaml
+values:
+  - values/custom.yaml
 tests:
   - it: should ensure the pdb has correct spec
     template: pdb.yaml
@@ -54,3 +47,16 @@ tests:
       - matchRegex:
           path: data["default.conf"]
           pattern: 'try_files \$uri /index.html;'
+  - it: should generate a deployment with the custom values
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.annotations["ad.datadoghq.com/web.logs"]
+          value: |
+            [
+              {"source":"nginx","service":"RELEASE-NAME"}
+            ]

--- a/charts/nginx-website/tests/defaults_test.yaml
+++ b/charts/nginx-website/tests/defaults_test.yaml
@@ -33,6 +33,8 @@ tests:
           value: {}
       - notExists:
           path: spec.template.spec.containers[0].resources
+      - notExists:
+          path: spec.template.metadata.annotations
   - it: should create a default nginx configuration
     template: nginx-configmap.yaml
     asserts:

--- a/charts/nginx-website/tests/values/custom-locations.yaml
+++ b/charts/nginx-website/tests/values/custom-locations.yaml
@@ -1,0 +1,41 @@
+nginx:
+  overrideLocations: |
+    location /starwars {
+        root   /dark/force/;
+        index  yoloo.html;
+        autoindex off;
+    }
+    location /statistics {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /plugin-trends {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /plugin-versions {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /dep-graph {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+    }
+podAnnotations:
+  ad.datadoghq.com/phs.logs: |
+    [
+      {"source":"java","service":"RELEASE-NAME"}
+    ]

--- a/charts/nginx-website/tests/values/custom.yaml
+++ b/charts/nginx-website/tests/values/custom.yaml
@@ -1,38 +1,14 @@
 service:
   port: 8080
 nginx:
-  overrideLocations: |
-    location /starwars {
-        root   /dark/force/;
-        index  yoloo.html;
-        autoindex off;
-    }
-    location /statistics {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-        try_files $uri /index.html;
-    }
-    location /plugin-trends {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-        try_files $uri /index.html;
-    }
-    location /plugin-versions {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-        try_files $uri /index.html;
-    }
-    location /dep-graph {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-        try_files $uri /index.html;
-    }
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-    }
+  serverName: _
+  slashLocation:
+    root: /custom
+    index: custom.html
+    autoindex: "off"
+    tryFiles: $uri /index.html
+podAnnotations:
+  ad.datadoghq.com/web.logs: |
+    [
+      {"source":"nginx","service":"RELEASE-NAME"}
+    ]

--- a/charts/nginx-website/values.yaml
+++ b/charts/nginx-website/values.yaml
@@ -37,6 +37,7 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 nodeSelector: {}
+podAnnotations: {}
 tolerations: []
 affinity: {}
 # the volume to mount


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4680

Another chart for which we want to pass custom annotations on the deployment.

Note: also removes the "I have no idea what is the purpose of it" config checksum annotation