### PR TITLE
fix(maven-cacher) write the cache archive directly to the destination instead of using /tmp to avoid weird disk space issues

### DIFF
--- a/charts/maven-cacher/Chart.yaml
+++ b/charts/maven-cacher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Maven Cache updater for the *.jenkins.io controllers
 name: maven-cacher
-version: 0.0.2
+version: 0.0.3
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/maven-cacher/templates/configmap-scripts.yaml
+++ b/charts/maven-cacher/templates/configmap-scripts.yaml
@@ -38,6 +38,5 @@ data:
     pushd "${mvn_local_repo}"
     df -h .
     du -sh .
-    time tar czf /tmp/maven-bom-local-repo.tar.gz ./
-    time cp /tmp/maven-bom-local-repo.tar.gz "${mvn_cache_archive}"
+    time tar czf "${mvn_cache_archive}" ./
     du -sh "${mvn_cache_dir}"/*


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4752