### PR TITLE
fix(artifact-caching-proxy) ensure file caching is enabled when handling proxy redirected URLs

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.6.7
+version: 1.6.8

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -176,16 +176,17 @@ data:
         location @handle_redirects {
             # We need to capture these values now otherwise they disappear
             # as soon as we invoke the proxy_* directives
-            set $original_uri $uri;
-            set $orig_loc $upstream_http_location;
+            set $original_uri   $uri;
+            set $orig_loc       $upstream_http_location;
 
             # Send the request to the URL passed in the `Location` header of the response
-            proxy_pass $orig_loc;
+            proxy_pass          $orig_loc;
 
             # Cache the result with the cache key of the original request URI
             # so that future requests won't need to follow the redirect too
-            proxy_cache_key $original_uri;
-            include /etc/nginx/conf.d/common-proxy.conf;
+            proxy_cache_key     $original_uri;
+            include             /etc/nginx/conf.d/common-proxy.conf;
+            include             /etc/nginx/conf.d/proxy-cache.conf;
         }
 
         # Endpoint used to check healthiness of the service before running Maven commands in Jenkins pipelines


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4747#issuecomment-3150474047

The artifacts retrieved after performing a redirection in the upstream/backend part (e.g. Nginx had to re-emit a new HTTP request to the `Location` header from the initial proxied upstream response) should be cached.

I'm not sure if it even worked as the `proxy-cache.conf` must be included to enable caching of the retrieved file, despite the `proxy_cache_key` directive set.

Tested on local ACP installation and manually in production 

