### PR TITLE
fix(mirrorbits) correct default downloads log path

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.8.0
+version: 5.8.1
 appVersion: "v0.6.0"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -204,7 +204,7 @@ tests:
           decodeBase64: true
       - matchRegex:
           path: data["mirrorbits.conf"]
-          pattern: 'LogDir: /var/logs/mirrorbits'
+          pattern: 'LogDir: /var/log/mirrorbits'
           decodeBase64: true
       - matchRegex:
           path: data["mirrorbits.conf"]

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -89,10 +89,11 @@ config:
   geoipDatabase: /usr/share/GeoIP
   disallowRedirects: true
   disableOnMissingFile: true
-  ## config.logs specify where to mount mirrorbits detailled logs directory.
+  ## config.logs specify where to mount mirrorbits detailed logs directory.
   logs:
-    ## config.logs.path specifies the logs path. Default as a download.logs symlink to stdout
-    path: /var/logs/mirrorbits
+    ## config.logs.path specifies the logs path.
+    # By default, jenkins-infra Docker image has a symlink /var/log/mirrorbits/downloadsLogs to stdout
+    path: /var/log/mirrorbits
     ## config.logs.volume contains the Pod Volume definition for mirrorbits logs
     ## Example with an existing PVC:
     # volume:


### PR DESCRIPTION
This PR should fix the error message from our mirrorbits logs:

```
Cannot open log file /var/logs/mirrorbits/downloads.log
```

Note: by default, on the Jenkins Infra Docker image, the path `/var/logs/mirrorbits/downloads.log` is a symlink to stdout => this fix should not have any I/O impact since it writes to the buffered stdout, managed by kubelet or container engine (and not in a container local file, which is readonly on the container overlay rootfs of our production)