### PR TITLE
fix(mirrorbits) ensure we can write the PID file at startup

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 5.8.1
+version: 5.8.2
 appVersion: "v0.6.0"
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/mirrorbits/templates/deployment.yaml
+++ b/charts/mirrorbits/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
             - name: tmpdir
               mountPath: /tmp
               readOnly: false
+            - name: rundir
+              mountPath: /run/mirrorbits
+              readOnly: false
           livenessProbe:
             httpGet:
               path: /?mirrorstats
@@ -127,3 +130,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 100Mi
+        - name: rundir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi

--- a/charts/mirrorbits/tests/defaults_test.yaml
+++ b/charts/mirrorbits/tests/defaults_test.yaml
@@ -105,6 +105,25 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[3].readOnly
           value: false
+      # Rundir for PID (tmpfs)
+      - equal:
+          path: spec.template.spec.volumes[4].name
+          value: rundir
+      - equal:
+          path: spec.template.spec.volumes[4].emptyDir.medium
+          value: Memory
+      - equal:
+          path: spec.template.spec.volumes[4].emptyDir.sizeLimit
+          value: 1Mi
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].name
+          value: rundir
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].mountPath
+          value: /run/mirrorbits
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[4].readOnly
+          value: false
       - equal:
           path: spec.template.spec.containers[0].ports[0].name
           value: http
@@ -113,7 +132,7 @@ tests:
           value: 8080
       # There are no log volumes
       - notExists:
-          path: spec.template.spec.volumes[4]
+          path: spec.template.spec.volumes[5]
       - notExists:
           path: spec.template.spec.securityContext
       - notExists:


### PR DESCRIPTION
Fix the error message, during mirrorbits startup, when the rootfs is in readonly:

```
Unable to write pid file: open /run/mirrorbits/mirrorbits.pid: read-only file system
```