### PR TITLE
feat(jenkins-jobs)! defaults multibranch jobs PRs to use 'The current pull request revision' strategy

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Jenkins Infra Team <jenkins-infra-team@googlegroups.com>
 name: jenkins-jobs
-version: 2.3.0
+version: 3.0.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
@@ -52,10 +52,14 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
               strategyId(1) // 1-only branches that are not pull requests
             }
             gitHubPullRequestDiscovery {
-              strategyId(1) // 1-Merging the pull request with the current target branch revision
+              // 1 - Merging the pull request with the current target branch revision
+              // 2 - The current pull request revision
+              strategyId({{ .mergePrWithTargetRevision | default false | ternary "1" "2"  }})
             }
             gitHubForkDiscovery {
-              strategyId(1) // 1-Merging the pull request with the current target branch revision
+              // 1 - Merging the pull request with the current target branch revision
+              // 2 - The current pull request revision
+              strategyId({{ .mergePrWithTargetRevision | default false | ternary "1" "2"  }})
               trust {
                 gitHubTrustPermissions()
               }

--- a/charts/jenkins-jobs/tests/fixtures/multibranch_customadvanced.yaml
+++ b/charts/jenkins-jobs/tests/fixtures/multibranch_customadvanced.yaml
@@ -11,3 +11,4 @@ jobsDefinition:
     buildOnFirstIndexing: true
     orphanedItemStrategyDaysToKeep: 3
     orphanedItemStrategyNumToKeep: 10
+    mergePrWithTargetRevision: true

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -50,10 +50,14 @@ tests:
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
                               gitHubPullRequestDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                               }
                               gitHubForkDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                                 trust {
                                   gitHubTrustPermissions()
                                 }
@@ -155,10 +159,14 @@ tests:
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
                               gitHubPullRequestDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                               }
                               gitHubForkDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                                 trust {
                                   gitHubTrustPermissions()
                                 }
@@ -260,10 +268,14 @@ tests:
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
                               gitHubPullRequestDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                               }
                               gitHubForkDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
                                 trust {
                                   gitHubTrustPermissions()
                                 }
@@ -365,10 +377,14 @@ tests:
                                 strategyId(1) // 1-only branches that are not pull requests
                               }
                               gitHubPullRequestDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(1)
                               }
                               gitHubForkDiscovery {
-                                strategyId(1) // 1-Merging the pull request with the current target branch revision
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(1)
                                 trust {
                                   gitHubTrustPermissions()
                                 }


### PR DESCRIPTION
BREAKING CHANGE: Set attribute `mergePrWithTargetRevision` For Multibranch jobs which requires the old strategy 'Merging the pull request with the current target branch revision'


<img width="1215" height="391" alt="Capture d’écran 2025-08-20 à 14 18 44" src="https://github.com/user-attachments/assets/c9a4920c-43ff-44eb-9797-da589dea60e6" />

