### PR TITLE
feat(nginx-website) add support of Nginx http-level directive

### DIFF
--- a/charts/nginx-website/Chart.yaml
+++ b/charts/nginx-website/Chart.yaml
@@ -6,4 +6,4 @@ name: nginx-website
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team
-version: 0.5.0
+version: 0.6.0

--- a/charts/nginx-website/templates/nginx-configmap.yaml
+++ b/charts/nginx-website/templates/nginx-configmap.yaml
@@ -5,19 +5,23 @@ metadata:
   labels: {{ include "nginx-website.labels" . | nindent 4 }}
 data:
   default.conf: |
+    # default.conf
+{{ if .Values.nginx.httpDirectives }}
+{{ .Values.nginx.httpDirectives | indent 4 }}
+{{ end }}
     server {
       listen       {{ .Values.service.port }};
       server_name  {{ .Values.nginx.serverName }};
-      {{- if .Values.nginx.overrideLocations }}
+{{- if .Values.nginx.overrideLocations }}
 {{ .Values.nginx.overrideLocations | indent 6 }}
-      {{- else }}
+{{- else }}
       location / {
         root   {{ .Values.nginx.slashLocation.root }};
         index  {{ .Values.nginx.slashLocation.index }};
         autoindex {{ .Values.nginx.slashLocation.autoindex }};
-        {{- if .Values.nginx.slashLocation.tryFiles }}
-        try_files {{ .Values.nginx.slashLocation.tryFiles }};
-        {{- end }}
+  {{- with .Values.nginx.slashLocation.tryFiles }}
+        try_files {{ . }};
+  {{- end }}
       }
-    {{- end }}
+{{- end }}
     }

--- a/charts/nginx-website/tests/custom_values_test.yaml
+++ b/charts/nginx-website/tests/custom_values_test.yaml
@@ -34,6 +34,9 @@ tests:
           value: RELEASE-NAME-nginx-website
       - matchRegex:
           path: data["default.conf"]
+          pattern: '# default.conf'
+      - matchRegex:
+          path: data["default.conf"]
           pattern: 'listen       8080;'
       - matchRegex:
           path: data["default.conf"]
@@ -47,6 +50,10 @@ tests:
       - matchRegex:
           path: data["default.conf"]
           pattern: 'try_files \$uri /index.html;'
+      - matchRegex:
+          path: data["default.conf"]
+          # Note: escaping regex special characters
+          pattern: 'map \$http_accept_language \$lang \{'
   - it: should generate a deployment with the custom values
     template: deployment.yaml
     asserts:

--- a/charts/nginx-website/tests/defaults_test.yaml
+++ b/charts/nginx-website/tests/defaults_test.yaml
@@ -63,6 +63,9 @@ tests:
           value: RELEASE-NAME-nginx-website
       - matchRegex:
           path: data["default.conf"]
+          pattern: '# default.conf'
+      - matchRegex:
+          path: data["default.conf"]
           pattern: 'listen       80;'
       - matchRegex:
           path: data["default.conf"]

--- a/charts/nginx-website/tests/values/custom.yaml
+++ b/charts/nginx-website/tests/values/custom.yaml
@@ -7,6 +7,12 @@ nginx:
     index: custom.html
     autoindex: "off"
     tryFiles: $uri /index.html
+  httpDirectives: |
+    map $http_accept_language $lang {
+      default '';
+      ~^zh zh;
+    }
+
 podAnnotations:
   ad.datadoghq.com/web.logs: |
     [

--- a/charts/nginx-website/values.yaml
+++ b/charts/nginx-website/values.yaml
@@ -62,18 +62,24 @@ nginx:
     autoindex: "on"
     ## Uncomment to enable try_files directive
     # tryFiles: $uri /index.html
-  # overrideLocations |
-  ## to allow customs locations
-  # location /statistics {
-  #     root   /usr/share/nginx/html;
-  #     index  index.html index.htm;
-  #     autoindex on;
-  #     try_files $uri /index.html;
-  # }
-  #
-  # location /plugin-trends {
-  #     root   /usr/share/nginx/html;
-  #     index  index.html index.htm;
-  #     autoindex on;
-  #     try_files $uri /index.html;
-  # }
+  ## Uncomment to set up custom locations
+  # overrideLocations: |
+  #   location /statistics {
+  #       root   /usr/share/nginx/html;
+  #       index  index.html index.htm;
+  #       autoindex on;
+  #       try_files $uri /index.html;
+  #   }
+
+  #   location /plugin-trends {
+  #       root   /usr/share/nginx/html;
+  #       index  index.html index.htm;
+  #       autoindex on;
+  #       try_files $uri /index.html;
+  #   }
+  ## Uncomment to set up custom directives at 'http' level
+  # httpDirectives: |
+  #   map $http_accept_language $lang {
+  #     default '';
+  #     ~^zh zh;
+  #   }


### PR DESCRIPTION
This PR adds supports of HTTP-level directives on this directive, so we can use it for www.jenkins.io (and deprecate its associated chart).