### PR TITLE
feat!(artifact-caching-proxy) stop mirroring incrementals repository

### DIFF
--- a/charts/artifact-caching-proxy/Chart.yaml
+++ b/charts/artifact-caching-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: artifact-caching-proxy is a Nginx caching proxy in front of repo.jenkins-ci.org
 name: artifact-caching-proxy
 type: application
-version: 1.6.13
+version: 2.0.0

--- a/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
+++ b/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml
@@ -86,20 +86,10 @@ data:
         recursive_error_pages on;
 
         # Non-cached requests
-        ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
+        ## Default location which tries the following chain: "jenkins public" -> "maven central"
         location ~* (maven-metadata.xml) {
             include             /etc/nginx/conf.d/common-proxy.conf;
             proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
-
-            proxy_intercept_errors on;
-            # Forbidden (403) resources on the backend should be answered "Not Found" (404) to content Maven
-            error_page 403 =404 /404.html;
-            # If the file is not found, then fallback the search in the "non-cached jenkins incrementals" upstream server
-            error_page 404 = @fallback_noncached_jenkins_incrementals;
-        }
-        location @fallback_noncached_jenkins_incrementals {
-            include             /etc/nginx/conf.d/common-proxy.conf;
-            proxy_pass          https://$jenkins_repo/incrementals$request_uri;
 
             proxy_intercept_errors on;
             # Forbidden (403) resources on the backend should be answered "Not Found" (404) to content Maven
@@ -118,31 +108,13 @@ data:
         }
 
         # Cached requests
-        ## Default location which tries the following chain: "jenkins public" -> "jenkins incrementals" -> "maven central"
+        ## Default location which tries the following chain: "jenkins public" -> "maven central"
         location / {
 {{- if .Values.proxy.proxyBypass.enabled -}}
             add_header Cache $upstream_cache_status;
             proxy_cache_bypass $bypass;
 {{- end }}
             proxy_pass          https://$jenkins_repo$initial_proxy_location$request_uri;
-            proxy_cache_key     $uri;
-            include             /etc/nginx/conf.d/common-proxy.conf;
-            include             /etc/nginx/conf.d/proxy-cache.conf;
-
-            proxy_intercept_errors on;
-            # If the file is not found, then fallback the search in the "jenkins incrementals" upstream server
-            error_page 404 = @fallback_jenkins_incrementals;
-            # If upstream respond with "HTTP 30x Redirect" then Nginx must re-emit a proxy request to the new location (see location @handle_redirects)
-            error_page 307 302 301 = @handle_redirects;
-        }
-
-        ## Fallback location to "jenkins incrementals" repository
-        location @fallback_jenkins_incrementals {
-{{- if .Values.proxy.proxyBypass.enabled -}}
-            add_header Cache $upstream_cache_status;
-            proxy_cache_bypass $bypass;
-{{- end }}
-            proxy_pass          https://$jenkins_repo/incrementals$request_uri;
             proxy_cache_key     $uri;
             include             /etc/nginx/conf.d/common-proxy.conf;
             include             /etc/nginx/conf.d/proxy-cache.conf;


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4998

Note: requires a full cache cleanup once deployed

BREAKING: artifacts served by https://repo.jenkins-ci.org/incrementals/ won't be available through artifact caching proxy anymore.