### PR TITLE
feat(jenkins-jobs) allow to disable branch discoveries

### DIFF
--- a/charts/jenkins-jobs/Chart.yaml
+++ b/charts/jenkins-jobs/Chart.yaml
@@ -4,5 +4,5 @@ icon: https://jenkins.io/images/logos/plumber/256.png
 maintainers:
   - name: Jenkins Infra Team <jenkins-infra-team@googlegroups.com>
 name: jenkins-jobs
-version: 3.1.0
+version: 3.2.0
 appVersion: "1.0" # unused

--- a/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
+++ b/charts/jenkins-jobs/templates/_jobDSL_jobs_multibranch.tpl
@@ -48,9 +48,11 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
               suppressLogs(true)
               unstableBuildNeutral(false)
             }
+            {{- if not .disableBranchDiscovery }}
             gitHubBranchDiscovery {
               strategyId(1) // 1-only branches that are not pull requests
             }
+            {{- end }}
             {{- if not .disablePullRequests }}
             gitHubPullRequestDiscovery {
               // 1 - Merging the pull request with the current target branch revision
@@ -98,7 +100,9 @@ multibranchPipelineJob('{{ .fullId | default .id }}') {
       {{- end }}
               }
     {{- end }}
+    {{- if not .disableBranchDiscovery }}
               buildRegularBranches()
+    {{- end }}
     {{- if not .disableTagDiscovery }}
               buildTags {
                 atLeastDays('-1')

--- a/charts/jenkins-jobs/tests/fixtures/multibranch_prs_only.yaml
+++ b/charts/jenkins-jobs/tests/fixtures/multibranch_prs_only.yaml
@@ -1,0 +1,5 @@
+jobsDefinition:
+  job-c:
+    name: Job C
+    disableTagDiscovery: true
+    disableBranchDiscovery: true

--- a/charts/jenkins-jobs/tests/manual/jenkins-jobs_values.yaml
+++ b/charts/jenkins-jobs/tests/manual/jenkins-jobs_values.yaml
@@ -10,6 +10,8 @@ jobsDefinition:
     kind: folder
     children:
       docker-404:
+        disableTagDiscovery: true
+        disableBranchDiscovery: true
       docker-404-production:
         allowUntrustedChanges: false
         disableTagDiscovery: true

--- a/charts/jenkins-jobs/tests/multibranch_job_test.yaml
+++ b/charts/jenkins-jobs/tests/multibranch_job_test.yaml
@@ -432,7 +432,7 @@ tests:
                     displayName('Job C')
                     description('Job C')
                   }
-  - it: should generate a multibranch job for "website production deployement" (with only principal branch for pipeline, No PR, no tags)
+  - it: should generate a multibranch job with only principal branch for pipeline, No PR, no tags
     values:
       - fixtures/multibranch_mainbranch_only.yaml
     asserts:
@@ -494,6 +494,106 @@ tests:
                               strategies {
                                 skipInitialBuildOnFirstBranchIndexing()
                                 buildRegularBranches()
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    factory {
+                      workflowBranchProjectFactory {
+                        scriptPath('Jenkinsfile_k8s')
+                      }
+                    }
+                    orphanedItemStrategy {
+                      defaultOrphanedItemStrategy {
+                        pruneDeadBranches(true)
+                        daysToKeepStr("")
+                        numToKeepStr("")
+                        abortBuilds(true)
+                      }
+                    }
+                    displayName('Job C')
+                    description('Job C')
+                  }
+  - it: should generate a multibranch job with only PRs, no branches, no tags
+    values:
+      - fixtures/multibranch_prs_only.yaml
+    asserts:
+      - equal:
+          path: data["jobs-definition.yaml"]
+          value: |
+            jobs:
+              - script: |
+
+                  multibranchPipelineJob('job-c') {
+                    triggers {
+                      periodicFolderTrigger {
+                        interval('2h')
+                      }
+                    }
+
+                    branchSources {
+                      branchSource {
+                        source {
+                          github {
+                            id('job-c')
+                            credentialsId('github-app-infra')
+                            configuredByUrl(true)
+                            repositoryUrl('https://github.com/jenkins-infra/job-c')
+                            repoOwner('jenkins-infra')
+                            repository('job-c')
+                            traits {
+                              gitHubNotificationContextTrait {
+                                contextLabel('jenkins/localhost/job-c')
+                                typeSuffix(true)
+                              }
+                              gitHubSCMSourceStatusChecksTrait {
+                                // Note: changing this name might have impact on github branch protections if they specify status names
+                                name('jenkins')
+                                skip(true)
+                                skipProgressUpdates(true)
+                                // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                                skipNotifications(false)
+                                // Default value: false. Warning: risk of secret leak in console if the build fails
+                                // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+                                suppressLogs(true)
+                                unstableBuildNeutral(false)
+                              }
+                              gitHubPullRequestDiscovery {
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
+                              }
+                              gitHubForkDiscovery {
+                                // 1 - Merging the pull request with the current target branch revision
+                                // 2 - The current pull request revision
+                                strategyId(2)
+                                trust {
+                                  gitHubTrustPermissions()
+                                }
+                              }
+                              pullRequestLabelsBlackListFilterTrait {
+                                labels('on-hold,ci-skip,skip-ci')
+                              }
+                              pruneStaleBranchTrait()
+                              // Select branches and tags to build based on these filters
+                              headWildcardFilterWithPR {
+                                includes('main master PR-*') // only branches listed here
+                                excludes('')
+                                tagIncludes('*')
+                                tagExcludes('')
+                              }
+                            }
+                          }
+                          buildStrategies {
+                            buildAnyBranches {
+                              strategies {
+                                skipInitialBuildOnFirstBranchIndexing()
+                                buildChangeRequests {
+                                  ignoreTargetOnlyChanges(true)
+                                  ignoreUntrustedChanges(true)
+                                }
                               }
                             }
                           }

--- a/charts/jenkins-jobs/values.yaml
+++ b/charts/jenkins-jobs/values.yaml
@@ -36,11 +36,14 @@ jobsDefinition: {}
 #         enableGitHubChecks: true
 #         disableGitHubNotifications: true
 #         githubCheckName: RogerRoger
-#          enableGitHubChecks: true
-#          allowUntrustedChanges: true
-#          jenkinsfilePath: Jenkinsfile
-#          branchIncludes: "prod dev MR-*"
-#          branchExcludes: "excluded"
+#         enableGitHubChecks: true
+#         allowUntrustedChanges: true
+#         jenkinsfilePath: Jenkinsfile
+#         branchIncludes: "prod dev MR-*"
+#         branchExcludes: "excluded"
+#         disableTagDiscovery: true
+#         disablePullRequests: true
+#         disableBranchDiscovery: true
 #         credentials:
 #            ssh-deploy-key:
 #              username: ${SSH_CHARTS_SECRETS_USERNAME}


### PR DESCRIPTION
With the following value change on our production:

```diff
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -727,6 +727,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_previews
         enableGitHubChecks: true
         disableTagDiscovery: true
+        disableBranchDiscovery: true
   website-production-jobs:
     name: Website Production Jobs
     description: "Folder hosting all the Website jobs dedicated to deployment in production"
```

we get the following `helmfile diff`:

```diff
                          // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
                          suppressLogs(true)
                          unstableBuildNeutral(false)
                        }
-                       gitHubBranchDiscovery {
-                         strategyId(1) // 1-only branches that are not pull requests
-                       }
                        gitHubPullRequestDiscovery {
                          // 1 - Merging the pull request with the current target branch revision
                          // 2 - The current pull request revision
                          strategyId(2)
...
                          buildChangeRequests {
                            ignoreTargetOnlyChanges(true)
                            ignoreUntrustedChanges(true)
                          }
-                         buildRegularBranches()
                        }
                      }
                    }
                  }
```

Required by https://github.com/jenkins-infra/kubernetes-management/pull/7633