### PR TITLE
feat(httpd): add optional PodDisruptionBudget

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: httpd helm chart for Kubernetes
 name: httpd
-version: 2.0.3
+version: 2.1.0
 appVersion: v2.4
 maintainers:
 - email: jenkins-infra-team@googlegroups.com

--- a/charts/httpd/templates/pdb.yaml
+++ b/charts/httpd/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "httpd.fullname" . }}
+  labels:
+{{ include "httpd.labels" . | indent 4 }}
+spec:
+  {{- with .Values.poddisruptionbudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.poddisruptionbudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "httpd.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/httpd/tests/custom_values_test.yaml
+++ b/charts/httpd/tests/custom_values_test.yaml
@@ -7,6 +7,7 @@ templates:
   - service.yaml
   - persistentVolume.yaml
   - persistentVolumeClaim.yaml
+  - pdb.yaml
 values:
   - values/custom.yaml
 tests:
@@ -128,6 +129,43 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /usr/local/apache2/htdocs
+  - it: should create a default pdb when replicated
+    template: pdb.yaml
+    set:
+      replicaCount: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: "httpd"
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: "RELEASE-NAME"
+  - it: should create a customized pdb when custom values are set
+    template: pdb.yaml
+    set:
+      replicaCount: 2
+      poddisruptionbudget:
+        minAvailable: null
+        maxUnavailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - notExists:
+          path: spec.minAvailable
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
   - it: should create ingress with pathType set to the specified custom value by default
     template: ingress.yaml
     asserts:

--- a/charts/httpd/tests/defaults_test.yaml
+++ b/charts/httpd/tests/defaults_test.yaml
@@ -7,6 +7,7 @@ templates:
   - persistentVolumeClaim.yaml
   - secret.yaml # Direct dependency of deployment.yaml
   - service.yaml
+  - pdb.yaml
 tests:
   - it: should not create any ingress by default
     template: ingress.yaml
@@ -78,6 +79,11 @@ tests:
           count: 0
   - it: should not define any PV claim
     template: persistentVolumeClaim.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not generate any pdb with default values
+    template: pdb.yaml
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+# A PodDisruptionBudget is only rendered when replicaCount is greater than 1.
+poddisruptionbudget:
+  minAvailable: 1
+  # maxUnavailable: 1
 image:
   repository: httpd
   tag: 2.4.68


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `PodDisruptionBudget` to the `httpd` chart, mirroring the one its twin `mirrorbits` already ships (ref #1109, and #837 for mirrorbits).

The PDB is only rendered when `replicaCount` is greater than 1, so the default single-replica install is unchanged. `poddisruptionbudget.minAvailable` defaults to `1`, and `maxUnavailable` is available as an alternative knob.

### Validation (local)

- `helm lint charts/httpd`: 0 failed
- `helm unittest --strict -f 'tests/*.yaml' charts/httpd`: 21 passed, including 3 new PDB cases (no PDB by default, default PDB when replicated, customized PDB)
- `helm template` render checks: no PDB at `replicaCount=1`; PDB with `minAvailable: 1` at `replicaCount=2`; `maxUnavailable` override renders as expected

`charts/httpd/Chart.yaml` is bumped `2.0.3` -> `2.1.0` per the versioning guideline.

closes #1109

---

Note: this change was prepared with the help of Claude Code (AI assistant); all code was reviewed and validated locally before submitting.