### PR TITLE
fix(maven-cacher) ensure the configmap is loaded from a local shell file (easier to reproduce) and fix shell errors

### DIFF
--- a/charts/maven-cacher/Chart.yaml
+++ b/charts/maven-cacher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Maven Cache updater for the *.jenkins.io controllers
 name: maven-cacher
-version: 1.0.0
+version: 1.0.1
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/maven-cacher/maven-cacher.sh
+++ b/charts/maven-cacher/maven-cacher.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eux -o pipefail
+
+mvn_cache_dir="${MVN_CACHE_DIR:-"/tmp"}"
+test -d "${mvn_cache_dir}"
+mvn_local_repo="${MVN_LOCAL_REPO:-"${HOME}/.m2/repository"}"
+mvn_cache_archive="${mvn_cache_dir}/maven-bom-local-repo.tar.gz"
+
+# Set up local working directory with BOM code
+test -d ./bom || git clone https://github.com/jenkinsci/bom
+pushd ./bom
+
+read -r -a build_lines <<< "${RELEASE_LINES:-}"
+
+# Load dependencies in the local Maven repo
+for build_line in "${build_lines[@]}"; do
+  MVN_OPTS=("-Dmaven.repo.local=${mvn_local_repo}")
+  if [[ $build_line != "weekly" ]]; then
+      MVN_OPTS+=("-P $build_line")
+  fi
+  time mvn -pl sample-plugin\
+      dependency:go-offline \
+      -DincludeScore=runtime,compile,test \
+      "${MVN_OPTS[@]}"
+done
+
+# Generate a new cache archive from the local Maven repository
+pushd "${mvn_local_repo}"
+df -h .
+du -sh .
+time tar czf "${mvn_cache_archive}" ./
+du -sh "${mvn_cache_dir}"/*

--- a/charts/maven-cacher/templates/configmap-scripts.yaml
+++ b/charts/maven-cacher/templates/configmap-scripts.yaml
@@ -5,37 +5,4 @@ metadata:
   labels: {{ include "maven-cacher.labels" . | nindent 4 }}
 data:
   maven-cacher.sh: |
-    #!/bin/bash
-
-    set -eux -o pipefail
-
-    mvn_cache_dir="${MVN_CACHE_DIR:-"/tmp"}"
-    test -d "${mvn_cache_dir}"
-    mvn_local_repo="${MVN_LOCAL_REPO:-"${HOME}/.m2/repository"}"
-    mvn_cache_archive="${mvn_cache_dir}/maven-bom-local-repo.tar.gz"
-
-    # Set up local working directory with BOM code
-    test -d ./bom || git clone https://github.com/jenkinsci/bom
-    pushd ./bom
-
-    read -r -a build_lines <<< "${RELEASE_LINES:-}"
-
-    # Load dependencies in the local Maven repo
-    for build_line in "${build_lines[@]}"; do
-      MVN_OPTS=()
-      if [[ $build_line != "weekly" ]]; then
-          MVN_OPTS+=("-P $build_line")
-      fi
-      time mvn -pl sample-plugin\
-          dependency:go-offline \
-          -DincludeScore=runtime,compile,test \
-          -Dmaven.repo.local="{{ .Values.mavenLocalRepo }}" \
-          "${MVN_OPTS[@]}"
-    done
-
-    # Generate a new cache archive from the local Maven repository
-    pushd "${mvn_local_repo}"
-    df -h .
-    du -sh .
-    time tar czf "${mvn_cache_archive}" ./
-    du -sh "${mvn_cache_dir}"/*
+{{ .Files.Get "maven-cacher.sh" | indent 4 }}


### PR DESCRIPTION
- chore: use the Helm `.File.Get` function to avoid having an inline shell script in the ConfigMap template (ref. https://helm.sh/docs/chart_template_guide/accessing_files/)
- fix: If ` MVN_OPTS` is empty (on weekly) then the script fails due to the `set -u` option
- chore: Fixes the `-Dmaven.repo.local` value passed to the `mvn` CLI as following:

```diff
-           -Dmaven.repo.local="/home/jenkins/.m2/repository" \
+           -Dmaven.repo.local="${mvn_local_repo}" \
```