### PR TITLE
feat(maven-cacher) increase the cache scope to the whole jenkinsci/bom and jenkinsci/jenkins top-level projects

### DIFF
--- a/charts/maven-cacher/Chart.yaml
+++ b/charts/maven-cacher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Maven Cache updater for the *.jenkins.io controllers
 name: maven-cacher
-version: 1.0.1
+version: 1.1.0
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/maven-cacher/maven-cacher.sh
+++ b/charts/maven-cacher/maven-cacher.sh
@@ -5,6 +5,10 @@ mvn_cache_dir="${MVN_CACHE_DIR:-"/tmp"}"
 test -d "${mvn_cache_dir}"
 mvn_local_repo="${MVN_LOCAL_REPO:-"${HOME}/.m2/repository"}"
 mvn_cache_archive="${mvn_cache_dir}/maven-bom-local-repo.tar.gz"
+# As 'dependency:go-offline' always use latest and until https://github.com/jenkins-infra/helpdesk/issues/5198 is fixed let's pin to 3.10.0
+mvn_dependency_offline_target='org.apache.maven.plugins:maven-dependency-plugin:3.10.0:go-offline'
+
+MVN_OPTS=("-Dmaven.repo.local=${mvn_local_repo}" "${mvn_dependency_offline_target}")
 
 # Set up local working directory with BOM code
 test -d ./bom || git clone https://github.com/jenkinsci/bom
@@ -12,14 +16,12 @@ pushd ./bom
 
 read -r -a build_lines <<< "${RELEASE_LINES:-}"
 
-# Load dependencies in the local Maven repo
+read -r -a build_lines <<< "${RELEASE_LINES:-}"
 for build_line in "${build_lines[@]}"; do
-  MVN_OPTS=("-Dmaven.repo.local=${mvn_local_repo}")
   if [[ $build_line != "weekly" ]]; then
       MVN_OPTS+=("-P $build_line")
   fi
-  time mvn -pl sample-plugin\
-      dependency:go-offline \
+  time mvn -pl sample-plugin \
       -DincludeScore=runtime,compile,test \
       "${MVN_OPTS[@]}"
 done

--- a/charts/maven-cacher/maven-cacher.sh
+++ b/charts/maven-cacher/maven-cacher.sh
@@ -35,4 +35,4 @@ pushd "${mvn_local_repo}"
 df -h .
 du -sh .
 time tar czf "${mvn_cache_archive}" ./
-du -sh "${mvn_cache_dir}"/*
+du -sh "${mvn_cache_dir}"/*.gz

--- a/charts/maven-cacher/maven-cacher.sh
+++ b/charts/maven-cacher/maven-cacher.sh
@@ -10,12 +10,15 @@ mvn_dependency_offline_target='org.apache.maven.plugins:maven-dependency-plugin:
 
 MVN_OPTS=("-Dmaven.repo.local=${mvn_local_repo}" "${mvn_dependency_offline_target}")
 
-# Set up local working directory with BOM code
+test -d ./jenkins || git clone https://github.com/jenkinsci/jenkins
+pushd ./jenkins
+time mvn "${MVN_OPTS[@]}"
+popd
+
 test -d ./bom || git clone https://github.com/jenkinsci/bom
 pushd ./bom
-
-read -r -a build_lines <<< "${RELEASE_LINES:-}"
-
+time mvn "${MVN_OPTS[@]}"
+# Stay in the bom for its sub-project 'sample-plugin'
 read -r -a build_lines <<< "${RELEASE_LINES:-}"
 for build_line in "${build_lines[@]}"; do
   if [[ $build_line != "weekly" ]]; then
@@ -25,6 +28,7 @@ for build_line in "${build_lines[@]}"; do
       -DincludeScore=runtime,compile,test \
       "${MVN_OPTS[@]}"
 done
+popd
 
 # Generate a new cache archive from the local Maven repository
 pushd "${mvn_local_repo}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5192

We want to increase the scope of the cache: we should expect an increase from ~1.2Gb to ~2.0Gb (and we'll have to watch the effect on the cache loading step which is around 11s today with the 1.2 Gb archive).

This PR introduces the following changes (1 per commit but all in one as tight all together for the initial issue):
- feat(maven-cacher) increase the cache scope to the whole jenkinsci/bom and jenkinsci/jenkins top-level projects
- fix(maven-cacher) pin the go-offline dependency to 3.10.0 until https://github.com/jenkins-infra/helpdesk/issues/5198 is fixed
- fix(maven-cacher) only calculate tar.gz archive size in the end (nit)