### PR TITLE
fix(maven-cacher) shell fmt and only target one BOM build_branch at a time

### DIFF
--- a/charts/maven-cacher/Chart.yaml
+++ b/charts/maven-cacher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Maven Cache updater for the *.jenkins.io controllers
 name: maven-cacher
-version: 1.1.0
+version: 1.1.1
 maintainers:
 - email: jenkins-infra-team@googlegroups.com
   name: jenkins-infra-team

--- a/charts/maven-cacher/maven-cacher.sh
+++ b/charts/maven-cacher/maven-cacher.sh
@@ -8,25 +8,26 @@ mvn_cache_archive="${mvn_cache_dir}/maven-bom-local-repo.tar.gz"
 # As 'dependency:go-offline' always use latest and until https://github.com/jenkins-infra/helpdesk/issues/5198 is fixed let's pin to 3.10.0
 mvn_dependency_offline_target='org.apache.maven.plugins:maven-dependency-plugin:3.10.0:go-offline'
 
-MVN_OPTS=("-Dmaven.repo.local=${mvn_local_repo}" "${mvn_dependency_offline_target}")
+mvn_global_opts=("-Dmaven.repo.local=${mvn_local_repo}" "${mvn_dependency_offline_target}")
 
 test -d ./jenkins || git clone https://github.com/jenkinsci/jenkins
 pushd ./jenkins
-time mvn "${MVN_OPTS[@]}"
+time mvn "${mvn_global_opts[@]}"
 popd
 
 test -d ./bom || git clone https://github.com/jenkinsci/bom
 pushd ./bom
-time mvn "${MVN_OPTS[@]}"
+time mvn "${mvn_global_opts[@]}"
 # Stay in the bom for its sub-project 'sample-plugin'
 read -r -a build_lines <<< "${RELEASE_LINES:-}"
 for build_line in "${build_lines[@]}"; do
-  if [[ $build_line != "weekly" ]]; then
-      MVN_OPTS+=("-P $build_line")
-  fi
-  time mvn -pl sample-plugin \
-      -DincludeScore=runtime,compile,test \
-      "${MVN_OPTS[@]}"
+    mvn_buildline_opts=("${mvn_global_opts[@]}")
+    if [[ $build_line != "weekly" ]]; then
+        mvn_buildline_opts+=("-P" "${build_line}")
+    fi
+    time mvn -pl sample-plugin \
+        -DincludeScore=runtime,compile,test \
+        "${mvn_buildline_opts[@]}"
 done
 popd
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5192

This PR fixes a bug introduced in #1978 regarding the loop on the BOM build branches: the flags `-P $build_branch` were combined as it appends to the same array variable and Maven was only catching the first one.
This fix has been tested locally.


Note: a quick shell format and a nit fix on the `-P $build_branc` string which is in fact 2 string elements
