### PR TITLE
chore(GHA/test) disable verification and retry when downloading unittests to support Helm v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,11 +77,7 @@ jobs:
         if: steps.list_modified_charts_with_unit_tests.outputs.modified_charts_with_unit_tests != ''
         run: |
           helm env
-          # Repeat 2 times to fight against network errors in  GHA runners
-          # Always return true
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${UNITTEST_VERSION} \
-            || helm plugin install https://github.com/helm-unittest/helm-unittest --version ${UNITTEST_VERSION} \
-            || true
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version ${UNITTEST_VERSION} --verify=false
           # Fail if not installed
           helm plugin list | grep unittest
       - id: run_helm_unittests


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5127#issuecomment-5000893154

Since we dynamically retrieve the Helm version from the deployed packer image (ref. https://github.com/jenkins-infra/helm-charts/blob/eefa4a79eb81c503876c41f72bc681bd2a8c50c9/.github/workflows/test.yml#L62-L68) the v3 -> v4 Helm upgrade was silent but broke the test GHA workflow.

Following the [plugin installation documentation](https://github.com/helm-unittest/helm-unittest#install), we have to disable the verification: 

<img width="990" height="1103" alt="Capture d’écran 2026-07-20 à 19 42 30" src="https://github.com/user-attachments/assets/a83c68a8-174e-4bf3-ab4a-b98ea550bdf4" />


Note: also removing the "retry" which is not a problem anymore